### PR TITLE
Update SDP industry FE demand trajectories for the calibration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.2.1
+Version: 0.2.2
 Date: 2020-05-28
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
@@ -54,7 +54,7 @@ License: LGPL-3 | file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.1.0
-ValidationKey: 386610
+ValidationKey: 405020
 Suggests: 
     knitr,
     testthat,

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -230,6 +230,12 @@ calcFEdemand <- function(subtype = "FE") {
       select(-'country', -'region') %>% 
       getElement('iso3c') 
 
+    sgma <- 8e3
+    cutoff <- 1.018
+    epsilon <- 0.018
+    exp1 <- 3
+    exp2 <- 1.5
+
     reduction_factor <- tmp_GDPpC %>%
       interpolate_missing_periods(year = seq_range(range(year)),
                                   value = 'GDPpC') %>%
@@ -237,11 +243,8 @@ calcFEdemand <- function(subtype = "FE") {
       mutate(
         # no reduction for SSA countries before 2050, to allow for more 
         # equitable industry and infrastructure development
-        a = ifelse(iso3c %in% SSA_countries & 2050 > year, -0.005, 0.002),
-        b = ifelse(iso3c %in% SSA_countries & 2050 > year,  2e-7,  3e-7),
-        f = cumprod(ifelse(2020 > year, 1,
-                           1 - ( pmin(0.007, !!sym('a') + !!sym('b') * GDPpC)
-                               * (1 - (year - 2020) / (2150 - 2020)))))) %>%
+        f = cumprod(ifelse(2020 > year, 1, pmin(cutoff, 1 + 4*epsilon*((sgma/GDPpC)^exp1 - (sgma/GDPpC)^exp2))
+                           ))) %>%
       ungroup() %>%
       select(-GDPpC) %>%
       filter(year %in% years)


### PR DESCRIPTION
Slightly changing the way the *correction factor* for industry FE demands is calculated, i.e., the factor that is used on SSP1/SSP2 industry FE demands to get SDP demands.

The changes are related to the new calibration data in https://github.com/remindmodel/remind/pull/178

The new factor aims to provide additional slack for poor countries to build infrastructure. Plotted in the time domain for all regions:

![Screenshot from 2020-05-28 12-41-28](https://user-images.githubusercontent.com/6737625/83131740-a0da4900-a0e0-11ea-97b1-32e6faae201f.png)

