### PR TITLE
Bugfix: re-included default source in calcFE and default subtype in calcPE.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.7.0
-Date: 2020-06-03
+Version: 0.7.1
+Date: 2020-06-23
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),
@@ -55,7 +55,7 @@ License: LGPL-3 | file LICENSE
 LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.1.0
-ValidationKey: 1289120
+ValidationKey: 1308956
 Suggests: 
     knitr,
     testthat,

--- a/R/calcFE.R
+++ b/R/calcFE.R
@@ -8,7 +8,7 @@
 #' @param scenario_proj "SSP2" by default unless overwritten
 
 
-calcFE <- function(source, scenario_proj = "SSP2") {
+calcFE <- function(source = "IEA", scenario_proj = "SSP2") {
   
   #------ READ-IN DATA----------------------------------------
   if (source == "IEA"){

--- a/R/calcPE.R
+++ b/R/calcPE.R
@@ -1,7 +1,7 @@
 #' @importFrom dplyr %>%
 #' @importFrom luscale speed_aggregate
 
-calcPE <- function(subtype) {
+calcPE <- function(subtype = "IEA") {
   
   if (subtype=="IEA"){
   


### PR DESCRIPTION
The value of a dependency in calcFE and calcPE used to be provided by default. In a previous commit this was removed, but the function calls were not updated accordingly. This change should provide the default value (used by most of the function calls) letting the user select a different entry only if needed.