### PR TITLE
Bugfix to a subtype call in the readEDGETransport function

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3403816'
+ValidationKey: '3533691'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .RData
 .Ruserdata
 fe_variables.csv
-.buildlibrary

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.18.4",
+  "version": "0.19.1",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.19.0
-Date: 2020-08-25
+Version: 0.19.1
+Date: 2020-08-27
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),
@@ -61,4 +61,3 @@ Suggests:
     rmarkdown,
     ggplot2
 VignetteBuilder: knitr
-ValidationKey: 3514810

--- a/R/readEDGETransport.R
+++ b/R/readEDGETransport.R
@@ -17,7 +17,7 @@
 
 readEDGETransport <- function(subtype = "logit_exponent") {
   ## mask variable for code checks
-  vehicle_type <- EDGE_scenario <- GDP_scenario <- value <- year <- sharetype <- NULL
+  vehicle_type <- EDGE_scenario <- GDP_scenario <- value <- year <- sharetype <- varname <- NULL
 
   switch(subtype,
 
@@ -267,10 +267,8 @@ readEDGETransport <- function(subtype = "logit_exponent") {
 
          "shares_LDV_transport" = {
            tmp <- fread(paste0(subtype, ".cs4r"))
-
-           tmp$varname <- subtype
-           tmp$varname = gsub(".*moinputData/","",tmp$varname)
-           tmp = melt(tmp, id.vars = c("GDP_scenario", "EDGE_scenario", "iso", "year", "varname"))
+           tmp[, varname := subtype]
+           tmp = data.table::melt(tmp, id.vars = c("GDP_scenario", "EDGE_scenario", "iso", "year", "varname"))
            setnames(tmp, old = "variable", new = "sharetype")
            tmp[, c("sharetype", "year") := list(as.character(sharetype), as.character(year))]
            setcolorder(tmp, c("GDP_scenario", "EDGE_scenario", "iso", "year", "sharetype", "varname", "value"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.18.4**
+R package **mrremind**, version **0.19.1**
 
   
 
@@ -38,11 +38,15 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou
-I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A,
-Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R,
-Rauner S, Dietrich J, Bi S (2020). _mrremind: MadRat REMIND Input Data
-Package_. R package version 0.18.4.
+Baumstark L, Rodrigues R, Levesque
+A, Oeser J, Bertram C, Mouratiadou
+I, Malik A, Schreyer F, Soergel B,
+Rottoli M, Mishra A, Dirnaichner A,
+Pehl M, Giannousakis A, Klein D,
+Strefler J, Feldhaus L, Brecha R,
+Rauner S, Dietrich J, Bi S (2020).
+_mrremind: MadRat REMIND Input Data
+Package_. R package version 0.19.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -51,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi},
   year = {2020},
-  note = {R package version 0.18.4},
+  note = {R package version 0.19.1},
 }
 ```
 


### PR DESCRIPTION
This bugfix should solve the issue encountered during the data preparation routine. The PR also includes the removal of `.buildlibrary` from the `.gitignore` file