### PR TITLE
add capacity targets for electrolysis in EU and DEU for NDC

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3552384'
+ValidationKey: '3701400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.19.2
-Date: 2020-08-28
+Version: 0.20.0
+Date: 2020-09-02
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.19.2**
+R package **mrremind**, version **0.20.0**
 
   
 
@@ -38,15 +38,10 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A,
-Oeser J, Bertram C, Mouratiadou I,
-Malik A, Schreyer F, Soergel B,
-Rottoli M, Mishra A, Dirnaichner A,
-Pehl M, Giannousakis A, Klein D,
-Strefler J, Feldhaus L, Brecha R,
-Rauner S, Dietrich J, Bi S (2020).
-_mrremind: MadRat REMIND Input Data
-Package_. R package version 0.19.2.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer
+F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler
+J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S (2020). _mrremind: MadRat REMIND Input
+Data Package_. R package version 0.20.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +50,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi},
   year = {2020},
-  note = {R package version 0.19.2},
+  note = {R package version 0.20.0},
 }
 ```
 


### PR DESCRIPTION
Add NDC capacity targets for electrolysis in 2025 and 2030 following recent EU Commission Hydrogen Strategy and German Hydrogen Strategy (see links in code). Relevant for REMIND-EU. The EU-wide target of 40GW in the EU is disaggregated to subregions (which do not have national target) by GDP. Note: The unit is GW(input) of electrolysis, so this still needs to be multiplied by the electrolysis efficiency in the datainput code. 