### PR TITLE
Add TtW efficiency values to calculate real UE values.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4260060'
+ValidationKey: '4446960'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.23.0
-Date: 2020-09-17
+Version: 0.24.0
+Date: 2020-09-24
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -649,6 +649,16 @@ calcFEdemand <- function(subtype = "FE") {
       reminditems[,,setdiff(getNames(reminditems),
                             getNames(SDP_industry_transport))],
       SDP_industry_transport)
+
+    ## calculate *real* useful (i.e., motive) energy instead of
+    ## fossil-fuel equivalents for light- and heavy-duty vehicles
+    ## sources for TtW efficiencies:
+    ##  Cox, B., et al. (2020) Life cycle environmental and cost comparison of current and future passenger cars under different energy scenarios. Applied Energy2.
+    ## Sacchi, R., et al. (2020) carculator: an open-source tool for prospective environmental and economic life cycle assessment of vehicles. When, Where and How can battery-electric vehicles help reduce greenhouse gas emissions? Renewable and Sustainable Energy Reviews, submitted (in review). https://www.psi.ch/en/media/57994/download
+
+    reminditems[,, "ueLDVt"] <- reminditems[,, "ueLDVt"] * 0.22
+    reminditems[,, "ueHDVt"] <- reminditems[,, "ueHDVt"] * 0.24
+
     
     # ---- Industry subsectors data stubs ----
     industry_subsectors_ue <- readSource('EDGE_Industry', 

--- a/R/calcTranspEff.R
+++ b/R/calcTranspEff.R
@@ -14,11 +14,17 @@
 calcTranspEff <- function(){
  
   x <- readSource("REMIND_11Regi", subtype = "transpEff")
+  ## the data is provided for energy service per "fossil-fuel equivalents".
+  ## to obtain the ES for a given motive energy, we have to divide by
+  ## tank-to-wheel efficiencies
+  x[,, "Eff_Pass_LDV"] <- x[,, "Eff_Pass_LDV"] / 0.22
+  x[,, c("Eff_Pass_nonLDV", "Eff_Freight")] <- x[,, c("Eff_Pass_nonLDV", "Eff_Freight")] / 0.24
   weights <- calcOutput("FE", aggregate = FALSE, years=2005)[,,"FE|Transport (EJ/yr)"]
+
+
   
   return(list(x           = x,
               weight      = weights,
               unit        = "range 0..1, bn pkm/EJ",
               description = "regionalized transport mode shares and efficiencies"))
 }
-  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.23.0**
+R package **mrremind**, version **0.24.0**
 
   
 
@@ -38,9 +38,11 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A,
-Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S (2020).
-_mrremind: MadRat REMIND Input Data Package_. R package version 0.23.0.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou
+I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A,
+Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R,
+Rauner S, Dietrich J, Bi S (2020). _mrremind: MadRat REMIND Input Data
+Package_. R package version 0.24.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,7 +51,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi},
   year = {2020},
-  note = {R package version 0.23.0},
+  note = {R package version 0.24.0},
 }
 ```
 


### PR DESCRIPTION
For transport demand trajectories, at the moment REMIND uses "fossil-fuel equivalents" which is not in line with the common understanding of useful energy. Instead, I suggest to use motive energy and consequently tank-to-wheel efficiencies as conversion factors from FE to UE.

Sources for the TtW efficiencies are given directly in the source code.

Note: This requires also a change to the `generisdata_tech.prn` in REMIND, so once this is merged and there is new inputdata, the corresponding patch to REMIND should also be merged. I will link the PR as soon as it is available.