### PR TITLE
Slightly modify the transport demand convergence for SDP

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5453112'
+ValidationKey: '5471660'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.29.4",
+  "version": "0.29.5",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.29.4
+Version: 0.29.5
 Date: 2020-10-13
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -90,7 +90,7 @@ calcFEdemand <- function(subtype = "FE") {
       it <- "ueLDVt"
       target <- 7 ## GJ
       switch_yrs <- 10
-      drive <- 0.1
+      drive <- 0.12
       prv_row <- newdem[year == yr - 5 & item == it]
       newdem[year == yr & item == it,
              window := ifelse(prv_row$dem_cap - target >= 0,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.29.4**
+R package **mrremind**, version **0.29.5**
 
   
 
@@ -38,9 +38,11 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner
-A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S (2020). _mrremind: MadRat REMIND Input
-Data Package_. R package version 0.29.4.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou
+I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A,
+Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R,
+Rauner S, Dietrich J, Bi S (2020). _mrremind: MadRat REMIND Input Data
+Package_. R package version 0.29.5.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,7 +51,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi},
   year = {2020},
-  note = {R package version 0.29.4},
+  note = {R package version 0.29.5},
 }
 ```
 


### PR DESCRIPTION
to be on the middle ground between the first SDP round and the
second (where FE demands from transport were too high for SSA).