### PR TITLE
add readREMIND_EU() and update calcFEdemand() for tuned industry FE calibration data

### DIFF
--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -576,7 +576,22 @@ calcFEdemand <- function(subtype = "FE") {
   getNames(reminditems) <- gsub("SDP","gdp_SDP",getNames(reminditems))
 
   if ('FE' == subtype) {
-
+    
+    # ---- _replace industry FE demand for Europe by REMIND-EU-tuned data ----
+    # read REMIND-EU data
+    replacement <- readSource(type = 'REMIND_EU',
+                              subtype = 'fixed_shares_FE_calibration_data',
+                              convert = FALSE)
+    
+    # harmonise dimension names
+    dimnames(replacement) <- setNames(
+      dimnames(replacement),
+      names(dimnames(reminditems)))
+    
+    # overwrite data
+    reminditems[getRegions(replacement),getYears(replacement),
+                getNames(replacement)] <- replacement
+    
     # ---- _modify SSP1/SSP2 data of CHN/IND further ----
     # To achieve projections more in line with local experts, apply tuning 
     # factor f to liquids and gas consumption in industry in CHN and IND. 

--- a/R/readREMIND_EU.R
+++ b/R/readREMIND_EU.R
@@ -26,17 +26,7 @@ readREMIND_EU <- function(subtype) {
                col_names = c('t', 'regi', 'SSP', 'pf', 'value'),
                col_types = 'icccd',
                comment = '*') %>% 
-        # # add useless NA data to please the all-mighty madrat god
-        # complete(nesting(t, SSP, pf), 
-        #          regi = read_delim(
-        #            file = system.file('extdata', 'iso_country.csv', 
-        #                               package = 'madrat'),
-        #            delim = ';',
-        #            col_names = 'iso3c',
-        #            col_types = '-c',
-        #            skip = 1) %>% 
-        #            pull('iso3c')) %>% 
-        as.magpie(spatial = 4, temporal = 1) %>% 
+        as.magpie(spatial = 2, temporal = 1) %>% 
         return()
     },
     

--- a/R/readREMIND_EU.R
+++ b/R/readREMIND_EU.R
@@ -1,0 +1,54 @@
+#' Read REMIND-EU Data
+#' 
+#' Read REMIND-EU data
+#' 
+#' @md
+#' @param subtype One of
+#'   * `fixed_shares_FE_calibration_data` for the projections of 
+#'     industry FE demand tuned for REMIND-EU
+#' 
+#' @return A [`magpie`][magclass::magclass] object.
+#' 
+#' @author Michaja Pehl
+#' 
+#' @seealso [`readSource()`]
+#' 
+#' @importFrom dplyr %>% filter pull
+#' @importFrom readr read_csv read_delim
+
+#' @export
+readREMIND_EU <- function(subtype) {
+  
+  # ---- list all available subtypes with functions doing all the work ----
+  switchboard <- list(
+    fixed_shares_FE_calibration_data = function() {
+      read_csv(file = 'pm_fe_demand_REMIND-EU.csv',
+               col_names = c('t', 'regi', 'SSP', 'pf', 'value'),
+               col_types = 'icccd',
+               comment = '*') %>% 
+        # # add useless NA data to please the all-mighty madrat god
+        # complete(nesting(t, SSP, pf), 
+        #          regi = read_delim(
+        #            file = system.file('extdata', 'iso_country.csv', 
+        #                               package = 'madrat'),
+        #            delim = ';',
+        #            col_names = 'iso3c',
+        #            col_types = '-c',
+        #            skip = 1) %>% 
+        #            pull('iso3c')) %>% 
+        as.magpie(spatial = 4, temporal = 1) %>% 
+        return()
+    },
+    
+    NULL
+  )
+  
+  # ---- check if the subtype called is available ----
+  if (is_empty(intersect(subtype, names(switchboard)))) {
+    stop(paste('Invalid subtype -- supported subtypes are:', 
+               names(switchboard)))
+  } else {
+    # ---- load data and do whatever ----
+    return(switchboard[[subtype]]())
+  }
+}

--- a/tests/testthat/test-readREMIND_EU.R
+++ b/tests/testthat/test-readREMIND_EU.R
@@ -1,0 +1,16 @@
+context('readREMIND-EU')
+
+test_that(
+  desc = 'Test readREMIND_EU() false subtype',
+  code = expect_error(
+    object = readREMIND_EU(subtype = NA),
+    regexp = paste('^Invalid subtype -- supported subtypes are:'))
+)
+
+test_that(
+  desc = 'Test readREMIND_EU() missing file',
+  code = expect_error(
+      object = readREMIND_EU(subtype = 'fixed_shares_FE_calibration_data'),
+      regexp = paste('\'pm_fe_demand_REMIND-EU.csv\' does not exist in',
+                     'current working directory'))
+)


### PR DESCRIPTION
- REMIND-EU uses industry/fixed_shares FE calibration data tuned to
  better match European country development
- calcFEdemand() is modified to substitute previously used data
- this will change Baseline scenarios for all non-REMIND-EU runs that
  use industry/fixed_shares, too (e.g., SDP)