### PR TITLE
Reference emissions and emission targets updates and bug-fixes

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '8481519'
+ValidationKey: '8612580'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.45.3",
+  "version": "0.46.0",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.45.3
+Version: 0.46.0
 Date: 2021-04-06
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcEffortSharingRefEmi.R
+++ b/R/calcEffortSharingRefEmi.R
@@ -1,7 +1,7 @@
 #' @title calc Effort Sharing Reference Emissions
 #' @description provides region specific Effort Sharing Reference Emissions
 #'
-#' @param subtype type of reference emissions used to define emission reduction target fo European Effort Sharing Decision: Eurostat_GHG, REMIND_GHG or REMIND_CO2.
+#' @param subtype type of reference emissions used to define emission reduction target fo European Effort Sharing Decision: EEA_GHG, Eurostat_GHG, REMIND_GHG (deprecated) or REMIND_CO2.
 #' @return 2005 reference emissions to calculate effort sharing decision targets
 #' @author Renato Rodrigues
 #' @examples
@@ -13,7 +13,13 @@
 
 calcEffortSharingRefEmi <- function(subtype){
   
-  if(subtype=="Eurostat_GHG"){
+  if(subtype=="EEA_GHG"){
+    e <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,2005,"Emi|GHG|ESD (Mt CO2-equiv/yr)"]
+    e[is.na(e)] <- 0
+    description <- "Effort sharing reference 2005 emissions in Mt CO2-equiv from EEA sectoral data" 
+    unit <- "Mt CO2-equiv"
+    
+  } else if(subtype=="Eurostat_GHG"){
     e <- readSource("Eurostat_EffortSharing",subtype="emissions")[,2005,] 
     description <- "Effort sharing reference 2005 emissions in Mt CO2-equiv from Eurostat" 
     unit <- "Mt CO2-equiv"
@@ -31,6 +37,7 @@ calcEffortSharingRefEmi <- function(subtype){
     e <- toolCountryFill(e,fill=0)
     description <- "Effort sharing reference 2005 emissions in Mt CO2-equiv from REMIND" 
     unit <- "Mt CO2-equiv"
+    
   } else if (subtype=="REMIND_CO2") {
     e_ES <- readSource("Eurostat_EffortSharing",subtype="emissions") 
     EU11map <- toolGetMapping("regionmapping_21_EU11.csv", type = "regional")
@@ -42,6 +49,7 @@ calcEffortSharingRefEmi <- function(subtype){
     e <- toolCountryFill(e,fill=0)
     description <- "Effort sharing reference 2005 emissions in Mt CO2 from REMIND" 
     unit <- "Mt CO2"
+    
   }
   getNames(e) <- NULL
   

--- a/R/calcEmiReference.R
+++ b/R/calcEmiReference.R
@@ -1,37 +1,55 @@
-#' @author Falk Benke
-#' @importFrom quitte calc_addVariable
+#' @title calc European Reference Emissions
+#' @description provides European 2030 emission targets (for 2030)reference 2005)
+#'
+#' @return 2030 emission reductions tragets for 40%, 55% and 64% reductions in relation to 2005 values
 
-calcEmiReference <-  function(){
+#' @author Falk Benke and Renato Rodrigues
+#' 
+#' @examples
+#' 
+#' \dontrun{ 
+#' calcOutput("EmiReference")
+#' }
+#' 
+
+calcEmiReference <-  function(subtype="EEA_sectoral"){
   
-  eea.emi.ets <- setNames(dimSums(readSource("EEA_EuropeanEnvironmentAgency",subtype="ETS")[,seq(2005,2019), c("2_ Verified emissions.20-99 All stationary installations","3_ Estimate to reflect current ETS scope for allowances and emissions.20-99 All stationary installations")]),"Emi|GHG|ETS (Mt CO2-equiv/yr)")
-  eea.emi.es <- readSource("EEA_EuropeanEnvironmentAgency",subtype="ES")
-  eea.emi <- rbind(as.data.frame(eea.emi.ets[,2005,]), as.data.frame(eea.emi.es[,2005,]))
-  eea.emi <- cbind(model=c("EEA"), eea.emi)
-
-  eurostat.emi <- readSource("EuropeanEnergyDatasheets")
-  eurostat.emi <- eurostat.emi[,1990,'Emi|GHGtot', pmatch=TRUE]
-  eurostat.emi <- as.data.frame(eurostat.emi)
-  eurostat.emi <- cbind(model=c("Eurostat"), eurostat.emi)
-
-  emi <- rbind(eea.emi, eurostat.emi)
-  emi$Cell <- NULL
-  colnames(emi) <- c("model", "region", "period", "variable", "value")
-  emi <- emi[!is.na(emi$value),]
-
-  emi <- emi %>% calc_addVariable(
-    "`Emi|GHGtot|target|40% (Mt CO2-equiv/yr)`" = "`Emi|GHGtot (Mt CO2-equiv/yr)` * 0.6",
-    "`Emi|GHGtot|target|55% (Mt CO2-equiv/yr)`" = "`Emi|GHGtot (Mt CO2-equiv/yr)` * 0.45",
-    "`Emi|GHGtot|target|65% (Mt CO2-equiv/yr)`" = "`Emi|GHGtot (Mt CO2-equiv/yr)` * 0.35",
-    "`Emi|GHG|ETS|target|40% (Mt CO2-equiv/yr)`" = "`Emi|GHG|ETS (Mt CO2-equiv/yr)` * 0.6",
-    "`Emi|GHG|ETS|target|55% (Mt CO2-equiv/yr)`" = "`Emi|GHG|ETS (Mt CO2-equiv/yr)` * 0.45",
-    "`Emi|GHG|ETS|target|65% (Mt CO2-equiv/yr)`" = "`Emi|GHG|ETS (Mt CO2-equiv/yr)` * 0.35",
-    "`Emi|GHG|ES|target|40% (Mt CO2-equiv/yr)`" = "`Emi|GHG|ES (Mt CO2-equiv/yr)` * 0.6",
-    "`Emi|GHG|ES|target|55% (Mt CO2-equiv/yr)`" = "`Emi|GHG|ES (Mt CO2-equiv/yr)` * 0.45",
-    "`Emi|GHG|ES|target|65% (Mt CO2-equiv/yr)`" = "`Emi|GHG|ES (Mt CO2-equiv/yr)` * 0.35",
-    units=c("Mt CO2-equiv/yr")
+  eea.emi.ets <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,,"Emi|GHG|ETS (Mt CO2-equiv/yr)"]
+  eea.emi.ets[is.na(eea.emi.ets)] <- 0
+  eea.emi.esd <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,,"Emi|GHG|ESD (Mt CO2-equiv/yr)"] 
+  eea.emi.esd[is.na(eea.emi.esd)] <- 0
+  
+  #Possible sources for 1990 emissions 
+  #(1) Table ES. 3GHG emissions in million tonnes CO2equivalent (excl. LULUCF)
+  # https://www.eea.europa.eu//publications/european-union-greenhouse-gas-inventory-2020
+  #eea.emi.total_no_lulucf <- 5658.7 #CO2 emissions include indirect CO2
+  #eea.emi.total <- 5413 #Total (with net CO2 emissions/removals)
+  # (2) EEA_EuropeanEnvironmentAgency
+  #eea.emi.total <- readSource("EEA_EuropeanEnvironmentAgency", subtype="total") # it possibly includes more than ETS + ESD (bunkers? and lulucf?) # eea.emi.total[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"] (total EU 1990 -> 5721.371)
+  # (3) EuropeanEnergyDatasheets
+  eea.emi.total_EEA <- readSource("EuropeanEnergyDatasheets") # it matches the EEA sectoral, so it should include only ETS + ESD, however it is the closest one to the CRF values for 1990, source 1 (total EU 1990 -> 5652.164), so it is being used as the default for now
+  # (4) EEA_sectoral, data only from 2005 onward
+  #eea.emi.total_EEA <- setNames(eea.emi.ets + eea.emi.esd, "Emi|GHGtot without Bunkers and LULUCF (Mt CO2-equiv/yr)") 
+  
+  # ETS + ESD emission target reduction in relation to 1990 = 40% reduction by 2030
+  out <- NULL
+  out <- mbind(out,
+               setNames(setYears(eea.emi.total_EEA[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"]*0.40,2030), "Emi|GHGtot|target|40% (Mt CO2-equiv/yr)"), # target without lulucf
+               setNames(setYears(eea.emi.total_EEA[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"]*0.55,2030), "Emi|GHGtot|target|55% (Mt CO2-equiv/yr)"), # target without lulucf
+               setNames(setYears(eea.emi.total_EEA[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"]*0.65,2030), "Emi|GHGtot|target|65% (Mt CO2-equiv/yr)")  # target without lulucf
+               )
+  
+  # ESD emission target - per country ESD reduction target for 2030 = reduction of 30% by 2030 compared to 2005
+  esd_target <- readSource("Eurostat_EffortSharing",subtype="target")
+  out <- mbind(out,
+               setNames(setYears(eea.emi.esd[,2005,]*(1+esd_target[,2020,]),2020), "Emi|GHG|ES|target|40% (Mt CO2-equiv/yr)"),
+               setNames(setYears(eea.emi.esd[,2005,]*(1+esd_target[,2030,]),2030), "Emi|GHG|ES|target|40% (Mt CO2-equiv/yr)")
   )
-
-  x <- as.magpie(emi)
-  x <- x[,,"target", pmatch=TRUE] %>% toolCountryFill(fill=0)
-  return(list(x=x,weight=NULL,unit="Mt CO2-equiv/yr",description="Emission reduction targets"))
+  
+  # ETS emission target (reduction of 2030 emissions by 43% compared to 2005)
+  out <- mbind(out,
+               setNames(setYears(eea.emi.ets[,2005,]*(1-0.43),2030), "Emi|GHG|ETS|target|40% (Mt CO2-equiv/yr)")
+  )
+  
+  return(list(x=out,weight=NULL,unit="Mt CO2-equiv/yr",description="Emission reduction targets"))
 }

--- a/R/calcHistorical.R
+++ b/R/calcHistorical.R
@@ -167,21 +167,21 @@ calcHistorical <- function() {
   eurostat <- add_dimension(eurostat, dim=3.1, add="model",nm="Eurostat")
   
   # Emissions market data
-  emiMktES <- setNames(readSource("Eurostat_EffortSharing",subtype="emissions"),"Emi|GHG|ES (Mt CO2-equiv/yr)") # Effort Sharing
-  emiMktETS <- setNames(dimSums(readSource("EEA_EuropeanEnvironmentAgency",subtype="ETS")[,seq(2005,2019), c("2_ Verified emissions.20-99 All stationary installations","3_ Estimate to reflect current ETS scope for allowances and emissions.20-99 All stationary installations")]),"Emi|GHG|ETS (Mt CO2-equiv/yr)") #ETS without aviation
-  # national aviation is not included in REMIND ETS yet
-  # aviation <- readSource("EEA_EuropeanEnvironmentAgency",subtype="ETS")[,seq(2005,2018),c("2_ Verified emissions.10 Aviation")]
-  #set all non EU values to NA (by doing this we are excluding from the ETS the non EU28 countries - Norway, Liechtenstein and Iceland - because REMIND is not including them in the ETS)
-  emiMktES[getRegions(emiMktES)[-which(getRegions(emiMktES) %in% EUcountries)],,] <- NA 
-  emiMktES <- add_dimension(emiMktES, dim=3.1, add="model",nm="Eurostat")
-  ETScountries <- c(EUcountries,"GRL","ISL","LIE","NOR","SJM","CHE")
-  emiMktETS[getRegions(emiMktETS)[-which(getRegions(emiMktETS) %in% ETScountries)],,] <- NA 
-  emiMktETS <- add_dimension(emiMktETS, dim=3.1, add="model",nm="EEA_historical")
-  # set remaining emissions to other market - it is missing lulucf (Land use, land-use change, and forestry)
-  totalGHG <- dimSums(eurostat[,,c("Emi|GHGtot (Mt CO2-equiv/yr)","Emi|GHG|Bunkers|International Aviation (Mt CO2-equiv/yr)","Emi|GHG|Bunkers|International Maritime Transport (Mt CO2-equiv/yr)")])
-  years <- Reduce(intersect, list(getYears(totalGHG),getYears(emiMktES[,,"Emi|GHG|ES (Mt CO2-equiv/yr)"]),getYears(emiMktETS[,,"Emi|GHG|ETS (Mt CO2-equiv/yr)"])))
-  emiMktESOthers <- setNames(collapseNames(totalGHG[,years,] - emiMktES[,years,"Emi|GHG|ES (Mt CO2-equiv/yr)"] - emiMktETS[,years,"Emi|GHG|ETS (Mt CO2-equiv/yr)"]),"Emi|GHG|other - Non ETS and ES (Mt CO2-equiv/yr)")
-  emiMktESOthers <- add_dimension(emiMktESOthers, dim=3.1, add="model",nm="Eurostat")
+  # emiMktES <- setNames(readSource("Eurostat_EffortSharing",subtype="emissions"),"Emi|GHG|ES (Mt CO2-equiv/yr)") # Effort Sharing
+  # emiMktETS <- setNames(dimSums(readSource("EEA_EuropeanEnvironmentAgency",subtype="ETS")[,seq(2005,2019), c("2_ Verified emissions.20-99 All stationary installations","3_ Estimate to reflect current ETS scope for allowances and emissions.20-99 All stationary installations")]),"Emi|GHG|ETS (Mt CO2-equiv/yr)") #ETS without aviation
+  # # national aviation is not included in REMIND ETS yet
+  # # aviation <- readSource("EEA_EuropeanEnvironmentAgency",subtype="ETS")[,seq(2005,2018),c("2_ Verified emissions.10 Aviation")]
+  # #set all non EU values to NA (by doing this we are excluding from the ETS the non EU28 countries - Norway, Liechtenstein and Iceland - because REMIND is not including them in the ETS)
+  # emiMktES[getRegions(emiMktES)[-which(getRegions(emiMktES) %in% EUcountries)],,] <- NA 
+  # emiMktES <- add_dimension(emiMktES, dim=3.1, add="model",nm="Eurostat")
+  # ETScountries <- c(EUcountries,"GRL","ISL","LIE","NOR","SJM","CHE")
+  # emiMktETS[getRegions(emiMktETS)[-which(getRegions(emiMktETS) %in% ETScountries)],,] <- NA 
+  # emiMktETS <- add_dimension(emiMktETS, dim=3.1, add="model",nm="EEA_historical")
+  # # set remaining emissions to other market - it is missing lulucf (Land use, land-use change, and forestry)
+  # totalGHG <- dimSums(eurostat[,,c("Emi|GHGtot (Mt CO2-equiv/yr)","Emi|GHG|Bunkers|International Aviation (Mt CO2-equiv/yr)","Emi|GHG|Bunkers|International Maritime Transport (Mt CO2-equiv/yr)")])
+  # years <- Reduce(intersect, list(getYears(totalGHG),getYears(emiMktES[,,"Emi|GHG|ES (Mt CO2-equiv/yr)"]),getYears(emiMktETS[,,"Emi|GHG|ETS (Mt CO2-equiv/yr)"])))
+  # emiMktESOthers <- setNames(collapseNames(totalGHG[,years,] - emiMktES[,years,"Emi|GHG|ES (Mt CO2-equiv/yr)"] - emiMktETS[,years,"Emi|GHG|ETS (Mt CO2-equiv/yr)"]),"Emi|GHG|other - Non ETS and ES (Mt CO2-equiv/yr)")
+  # emiMktESOthers <- add_dimension(emiMktESOthers, dim=3.1, add="model",nm="Eurostat")
   
   # EEA GHG Projections
   EEA_GHGProjections <- .fillZeros(readSource("EEA_EuropeanEnvironmentAgency", subtype="projections"))
@@ -193,9 +193,9 @@ calcHistorical <- function() {
   EEA_GHGTotal <- .fillZeros(readSource("EEA_EuropeanEnvironmentAgency", subtype="total"))
   EEA_GHGTotal <- add_dimension(EEA_GHGTotal, dim=3.1,add="model",nm="EEA_historical")
 
-  EEA_GHGES <- .fillZeros(readSource("EEA_EuropeanEnvironmentAgency", subtype="ES"))
-  EEA_GHGES <- add_dimension(EEA_GHGES, dim=3.1,add="model",nm="EEA_historical")
-    
+  # EEA_GHGES <- .fillZeros(readSource("EEA_EuropeanEnvironmentAgency", subtype="ES"))
+  # EEA_GHGES <- add_dimension(EEA_GHGES, dim=3.1,add="model",nm="EEA_historical")
+  #   
   # EU Reference Scenario
   EU_ReferenceScenario <- readSource("EU_ReferenceScenario")
   EU_ReferenceScenarioEU <- EU_ReferenceScenario[EUcountries,,]

--- a/R/calcHistorical.R
+++ b/R/calcHistorical.R
@@ -240,9 +240,9 @@ calcHistorical <- function() {
   
   # varlist <- list( fe, fe_proj, pe, trade, pop, gdpp, ceds, edgar, cdiac, LU_EDGAR_LU, LU_CEDS, LU_FAO_EmisLUC, LU_FAO_EmisAg, LU_PRIMAPhist, LU_IPCC, LU_Nsurplus2)
   varlist <- list(fe_iea, fe_weo, fe_proj, pe_iea, pe_weo, trade, pop, gdpp_James, gdpp_WB, gdpp_IMF, ceds, edgar, primap, cdiac, 
-                  LU_EDGAR_LU, LU_CEDS, LU_FAO_EmisLUC, LU_FAO_EmisAg, LU_PRIMAPhist, IRENAcap, eurostat, emiMktES, emiMktETS, 
-                  emiMktESOthers, EU_ReferenceScenario, emiEurostat, ARIADNE_ReferenceScenarioGdp, ARIADNE_ReferenceScenarioGdpCorona,
-                  ARIADNE_ReferenceScenarioPop, EEA_GHGSectoral, EEA_GHGTotal, EEA_GHGES, EEA_GHGProjections, Emi_Reference, 
+                  LU_EDGAR_LU, LU_CEDS, LU_FAO_EmisLUC, LU_FAO_EmisAg, LU_PRIMAPhist, IRENAcap, eurostat, #emiMktES, emiMktETS, emiMktESOthers, 
+                  EU_ReferenceScenario, emiEurostat, ARIADNE_ReferenceScenarioGdp, ARIADNE_ReferenceScenarioGdpCorona,
+                  ARIADNE_ReferenceScenarioPop, EEA_GHGSectoral, EEA_GHGTotal, EEA_GHGProjections, Emi_Reference, #, EEA_GHGES
                   IEA_ETPMain, IEA_ETPIndustrySub, INNOPATHS)
 
   y <- Reduce(union,lapply(varlist,getYears))

--- a/R/fullREMIND.R
+++ b/R/fullREMIND.R
@@ -150,7 +150,7 @@ fullREMIND <- function(rev=0) {
   calcOutput("CapTarget", sources="NDC+REN21+CHN_NUC",    round=4,  file="f40_NDC+REN21+CHN_NUC.cs4r")
   calcOutput("SharedTarget", subtype="FErenewablesShare", round=3,  file="f40_FE_RenShare.cs4r")
   calcOutput("EffortSharingTarget",                       round=3,  file="p47_EStarget.cs4r")
-  calcOutput("EffortSharingRefEmi", subtype="REMIND_GHG", round=6,  file="p47_ES_GHG_referenceEmissions.cs4r")
+  calcOutput("EffortSharingRefEmi", subtype="EEA_GHG"   , round=6,  file="p47_ES_GHG_referenceEmissions.cs4r")
   calcOutput("EffortSharingRefEmi", subtype="REMIND_CO2", round=6,  file="p47_ES_CO2_referenceEmissions.cs4r")
   calcOutput("TransportSubsidies",                        round=8,  file="f21_vehiclesSubsidies.cs4r")
   

--- a/R/readEEA_EuropeanEnvironmentAgency.R
+++ b/R/readEEA_EuropeanEnvironmentAgency.R
@@ -67,7 +67,7 @@ readEEA_EuropeanEnvironmentAgency <- function(subtype) {
     timeframe <- seq(2005, 2017) # excluding WEM projections
 
     for (s in sheets) {
-      tmp <- read_excel(path = "GHG_ETS_ES_Projections_by_sector.xlsx", sheet = s, skip = 1, trim_ws = T)
+      tmp <- suppressMessages(read_excel(path = "GHG_ETS_ES_Projections_by_sector.xlsx", sheet = s, skip = 1, trim_ws = T))
       tmp <- melt(tmp, id.vars = 1) 
       tmp <- mutate(tmp, !!sym("value") := ifelse(is.na(!!sym("value")), 0, !!sym("value"))) # set 0s for NAs
       colnames(tmp) <- c("label", "period", "value")

--- a/R/readEEA_EuropeanEnvironmentAgency.R
+++ b/R/readEEA_EuropeanEnvironmentAgency.R
@@ -77,16 +77,26 @@ readEEA_EuropeanEnvironmentAgency <- function(subtype) {
     mapping.variable <- as.data.frame(
       cbind(
         variable=c(
+          "Emi|GHG|ETS",
+          "Emi|GHG|Energy|ETS",
           "Emi|GHG|Industry|ETS",
-          "Emissions|CO2|Energy|Demand|Transportation",
-          "Emissions|CO2|Energy|Demand|Residential and Commercial",
-          "Emi|GHG|Industry|ESD"
+          "Emi|GHG|ESD",
+          "Emi|GHG|Transport|ESD",
+          "Emi|GHG|Buildings|ESD",
+          "Emi|GHG|Industry|ESD",
+          "Emi|GHG|Agriculture|ESD",
+          "Emi|GHG|Waste|ESD"
         ), 
         label=c(
+          "Emissions Trading System (stationary installations)",
+          "Energy Industries",
           "Other stationary installations",
+          "Effort Sharing Decision and Regulation",
           "Transport",
           "Buildings",
-          "Industry and other"
+          "Industry and other",
+          "Agriculture",
+          "Waste"
         )
       )
     )    

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.45.3**
+R package **mrremind**, version **0.46.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)   [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/mrremind)
 
@@ -38,9 +38,11 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A,
-Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S (2021).
-_mrremind: MadRat REMIND Input Data Package_. R package version 0.45.3.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou
+I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A,
+Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R,
+Rauner S, Dietrich J, Bi S (2021). _mrremind: MadRat REMIND Input Data
+Package_. R package version 0.46.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,7 +51,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi},
   year = {2021},
-  note = {R package version 0.45.3},
+  note = {R package version 0.46.0},
 }
 ```
 


### PR DESCRIPTION
* updating 1990 and 2005 reference emissions to better data sources
* updating 2020 and 2030 emission reduction targets
* bug-fixing wrongly defined historical mif targets for ESD and ETS
* disabling duplicated and/or unnecessary data from the historical mif
* adding missing mappings and bug-fix for EEA sectoral emissions data