### PR TITLE
Create input data from EDGE-B results with varying RCP scenario.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '13781670'
+ValidationKey: '13974900'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.73.0
-Date: 2021-09-09
+Version: 0.74.0
+Date: 2021-09-15
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/fullREMIND.R
+++ b/R/fullREMIND.R
@@ -39,6 +39,7 @@ fullREMIND <- function(rev=0) {
   calcOutput("Capital",                               round=6,  file="p29_capitalQuantity.cs4r")
   calcOutput("Capital",   subtype = "CapitalUnit",    round=6,  file="f29_capitalUnitProjections.cs4r")
   calcOutput("FEdemand",  subtype = "FE",             round=8,  file="pm_fe_demand.cs4r")
+  calcOutput("FEdemand",  subtype = "FE_buildings",   round=8,  file="pm_fe_demand_build.cs4r")
   calcOutput("FEdemand",  subtype = "ES",             round=6,  file="pm_es_demand.cs4r")
   calcOutput('Secondary_steel_limits',                round=8,  file='p37_cesIO_up_steel_secondary.cs4r')
   calcOutput("EnergyEffPaths",                        round=6,  file="p29_efficiency_growth.cs4r")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.73.0**
+R package **mrremind**, version **0.74.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)   [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.73.0.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.74.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke},
   year = {2021},
-  note = {R package version 0.73.0},
+  note = {R package version 0.74.0},
 }
 ```
 


### PR DESCRIPTION
With this PR, mrremind reads EDGE-B results that now have an RCP dimension in addition to the SSP scenario. For all existent inputfiles, only fixed climate is used giving identical results as before. `fullREMIND.R` now creates a new input file `pm_fe_demand_build.cs4r` that contains FE demands in buildings with the additional RCP dimension. This can later be used in REMIND to overwrite demands in buildings to consider specific climate change scenarios. Moreover, this PR introduces source data versioning for EDGE-B results.