### PR TITLE
Align floorspace scenario names with cm_demScen switch in REMIND.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '15312240'
+ValidationKey: '15331144'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.81.0
+Version: 0.81.1
 Date: 2021-10-04
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),

--- a/R/convertEDGE.R
+++ b/R/convertEDGE.R
@@ -318,23 +318,25 @@ convertEDGE <- function(x, subtype = "FE_stationary") {
     x = toolAggregate(x[,select_years,],mappingfile, weight = wg[,,getNames(x,dim=1)], from = region_col, to = iso_col )
     result = x
     
-  }else if(subtype == "Floorspace"){
+  } else if (subtype == "Floorspace") {
     mappingfile <- toolGetMapping(type = "regional", name = "regionmappingEDGE.csv", returnPathOnly = TRUE)
     mapping <- read.csv2(mappingfile)
     region_col = which(names(mapping) == "RegionCodeEUR_ETP")
     iso_col = which(names(mapping) == "CountryCode")
 
+    getNames(x) <- paste0("gdp_", getNames(x))
     wg <- calcOutput("Population", years = rem_years_hist, aggregate = FALSE)
-    # duplicate SSP2 for SSP2_lowEn
-    wg_SSP2_lowEn <- mselect(wg, variable = "pop_SSP2")
-    getItems(wg_SSP2_lowEn, "variable") <- "pop_SSP2_lowEn"
+    getSets(wg) <- gsub("variable", "scenario", getSets(wg))
+    getItems(wg, "scenario") <- gsub("pop_", "gdp_", getItems(wg, "scenario"))
+    # duplicate SSP2 population for SSP2_lowEn
+    wg_SSP2_lowEn <- mselect(wg, scenario = "gdp_SSP2")
+    getItems(wg_SSP2_lowEn, "scenario") <- "gdp_SSP2_lowEn"
     wg <- mbind(wg, wg_SSP2_lowEn)
-    getNames(x) <- paste0("pop_",getNames(x))
-    getSets(wg) = gsub("variable","scenario",getSets(wg))
-    wg = wg[,,getNames(x,T)[["scenario"]]]
+    wg <- wg[, , getItems(x, "scenario")]
     
-    x = toolAggregate(x[,rem_years_hist,],mappingfile, weight = wg, from = region_col, to = iso_col )
-    result = x
+    x <- toolAggregate(x[, rem_years_hist, ], mappingfile, weight = wg,
+                       from = region_col, to = iso_col )
+    result <- x
   }
   return(result)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.81.0**
+R package **mrremind**, version **0.81.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.81.0.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.81.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke},
   year = {2021},
-  note = {R package version 0.81.0},
+  note = {R package version 0.81.1},
 }
 ```
 


### PR DESCRIPTION
Renames floorspace scenarios from `pop_*` to `gdp_*` which corresponds to the values that `cm_demScen` takes in REMIND.