### PR TITLE
in calcDiffInvestCosts, use comparison.csv to map technologies

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '17082960'
+ValidationKey: '17101920'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.90.1",
+  "version": "0.90.2",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.90.1
+Version: 0.90.2
 Date: 2021-11-29
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcDiffInvestCosts.R
+++ b/R/calcDiffInvestCosts.R
@@ -49,8 +49,7 @@ calcDiffInvestCosts <- function(subtype){
   # list of original technologies with a REMIND tech mapping
   techs2 <- unique(tech_mapping$IEA[!is.na(tech_mapping$tech)])
   # create new magpie object with names of corresponding REMIND technologies
-  x_new <- new.magpie(getRegions(x),names = techs,years = getYears(x)) 
-  x_new[is.na(x_new)] <- 0
+  x_new <- new.magpie(getRegions(x),names = techs,years = getYears(x),fill = 0)
   # for "pc" add all types of coal plants so each country has one value of "pc"
   x_new[,,"pc"] <- x[,,"Coal.Steam Coal - SUBCRITICAL"] + x[,,"Coal.Steam Coal - SUPERCRITICAL"] + 
     x[,,"Coal.Steam Coal - ULTRASUPERCRITICAL"]
@@ -65,7 +64,8 @@ calcDiffInvestCosts <- function(subtype){
   x_new[,,"biochp"] <- 0.75*x[,,"Renewables.Biomass CHP Medium"] + 0.25*x[,,"Renewables.Biomass CHP Small"]
   
   # for rest of technologies, simply match 
-  x_new[,,techs[-c(1,13,15,16)]] <- as.numeric(x[,,getNames(x,dim=2)[getNames(x,dim=2) %in% techs2[-c(1:3,15,16,18:21)]]])
+  further_techs_to_map <- techs[!techs %in% c("pc", "spv", "hydro", "biochp")]
+  x_new[,, further_techs_to_map] <- as.numeric(x[,, match(further_techs_to_map, tech_mapping[,2])])
   x_new <- time_interpolate(x_new,c(2025,2035),integrate_interpolated_years = T)
   
   # overwrite investmetn costs vor renewables with data form REN21

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.89.1**
+R package **mrremind**, version **0.90.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,15 +38,15 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.89.1.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.90.2.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {mrremind: MadRat REMIND Input Data Package},
-  author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke},
+  author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann},
   year = {2021},
-  note = {R package version 0.89.1},
+  note = {R package version 0.90.2},
 }
 ```


### PR DESCRIPTION
instead of inflexible hard-coded column numbers