### PR TITLE
Adjust filling of UNFCCC source data with zeros

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '17851711'
+ValidationKey: '17871624'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.94.1",
+  "version": "0.94.2",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.94.1
-Date: 2021-12-10
+Version: 0.94.2
+Date: 2021-12-11
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/calcUNFCCC.R
+++ b/R/calcUNFCCC.R
@@ -14,7 +14,7 @@
 calcUNFCCC <- function() {
 
   data <- readSource("UNFCCC")
-
+  
   mapping <- toolGetMapping("Mapping_UNFCCC.csv", type = "reportingVariables") %>%
     mutate(!!sym('conversion') := as.numeric(!!sym('Factor')) * !!sym('Weight')) %>%
     select('variable' = 'UNFCCC', 'REMIND', 'conversion', 'unit' = 'Unit_UNFCCC', 'Unit_REMIND')
@@ -33,14 +33,11 @@ calcUNFCCC <- function() {
     by = 'variable'
   ) %>% 
     filter(!!sym("REMIND") != "") %>%
-    mutate(!!sym('value') := ifelse(
-      is.na(!!sym('value')), 0,  !!sym('value') * !!sym('conversion')),
+    mutate(!!sym('value') := !!sym('value') * !!sym('conversion'),
       !!sym('REMIND') := paste0(!!sym('REMIND'),  " (", !!sym('Unit_REMIND'), ")")) %>%
     select('variable' = 'REMIND', 'region', 'year', 'value')
 
-  x <- aggregate(value ~ variable+region+year, x, sum) %>% 
-    as.magpie() %>% 
-    toolCountryFill(fill = 0)
+  x <- aggregate(value ~ variable+region+year, x, sum) %>% as.magpie() %>% toolCountryFill(fill = NA)
 
   # aggregate pollutants
   x <- add_columns(x, "Emi|CH4 (Mt CH4/yr)", dim=3.1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.94.1**
+R package **mrremind**, version **0.94.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.94.1.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O (2021). _mrremind: MadRat REMIND Input Data Package_. R package version 0.94.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,6 +47,6 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters},
   year = {2021},
-  note = {R package version 0.94.1},
+  note = {R package version 0.94.2},
 }
 ```


### PR DESCRIPTION
Fills all countries with NAs in the following regions with 0s to allow H12 aggregation: EUR, REF, NEU, CAZ. 
All other NAs are no longer filled with 0s to avoid zero values for regions like LAM which are not included in the source.