### PR TITLE
bug and linter warnings fixed

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '18996000'
+ValidationKey: '19014996'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.100.0
+Version: 0.100.1
 Date: 2022-01-04
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCapTarget.R
+++ b/R/calcCapTarget.R
@@ -68,7 +68,7 @@ calcCapTarget <- function(sources) {
     c(getNames(NDC), getNames(REN21), paste(names(listCapacitiesNDC), "apCarElT", sep = ".")) %>%
       unique() %>% sort() -> techNames
 
-    x <- new.magpie(getRegions(REN21), getYears(REN21), techNames)
+    x <- new.magpie(getItems(REN21, dim = "region"), getYears(REN21), techNames)
     # China's nuclear target
     common_tech <- intersect(
       getNames(REN21) %>% unlist() %>% unique(),
@@ -105,7 +105,7 @@ calcCapTarget <- function(sources) {
     H2Target.reg["EUR", "y2030", ] <- 40
 
     # Country Targets
-    H2Target.country <- new.magpie(getRegions(x), getYears(x), "elh2", fill = 0)
+    H2Target.country <- new.magpie(getItems(x, dim = "region"), getYears(x), "elh2", fill = 0)
     # iso countries with a country target that belong to the EU
     country.target.regs <- c("DEU")
     # Germany Target: https://www.bmbf.de/files/die-nationale-wasserstoffstrategie.pdf
@@ -118,12 +118,12 @@ calcCapTarget <- function(sources) {
     H2Target["EUR", , "elh2"] <- H2Target.reg["EUR", , "elh2"] - H2Target.CountryAgg["EUR", , "elh2"]
 
     # # SE VRE Production in 2015 to be used as weight for disaggregation EU target to iso countries
-    # SEHistVRE <- dimSums(calcOutput("FE", aggregate = F)[,"y2015",c("SE|Electricity|Solar (EJ/yr)",
+    # SEHistVRE <- dimSums(calcOutput("FE", aggregate = FALSE)[,"y2015",c("SE|Electricity|Solar (EJ/yr)",
     #                                                                 "SE|Electricity|Wind (EJ/yr)")],
     #                      dim = 3)
 
     # GDP 2015 to be used as weight for disaggregation of EU target to iso coutries
-    GDP2015 <- calcOutput("GDPPast", aggregate = F)[, "y2015", ]
+    GDP2015 <- calcOutput("GDPPast", aggregate = FALSE)[, "y2015", ]
 
     # regionmapping without countries that already have a country target
     CountryCode <- NULL

--- a/R/calcEmiReference.R
+++ b/R/calcEmiReference.R
@@ -4,59 +4,57 @@
 #' @return 2030 emission reductions tragets for 40%, 55% and 64% reductions in relation to 2005 values
 
 #' @author Falk Benke and Renato Rodrigues
-#' 
+#'
 #' @examples
-#' 
-#' \dontrun{ 
+#' \dontrun{
 #' calcOutput("EmiReference")
 #' }
-#' 
+#'
+calcEmiReference <-  function() {
 
-calcEmiReference <-  function(){
-  
-  #eea.emi.ets <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,,"Emi|GHG|ETS (Mt CO2-equiv/yr)"]
-  eea.emi.ets <- setNames(dimSums(readSource("EEA_EuropeanEnvironmentAgency", subtype="ETS")[,,c("2_ Verified emissions.20-99 All stationary installations","3_ Estimate to reflect current ETS scope for allowances and emissions.20-99 All stationary installations")]),"Emi|GHG|ETS (Mt CO2-equiv/yr)")
+  # eea.emi.ets <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,,"Emi|GHG|ETS (Mt CO2-equiv/yr)"]
+  eea.emi.ets <- setNames(dimSums(readSource("EEA_EuropeanEnvironmentAgency", subtype = "ETS")[, , c("2_ Verified emissions.20-99 All stationary installations", "3_ Estimate to reflect current ETS scope for allowances and emissions.20-99 All stationary installations")]), "Emi|GHG|ETS (Mt CO2-equiv/yr)")
   eea.emi.ets[is.na(eea.emi.ets)] <- 0
-  #eea.emi.esr <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,,"Emi|GHG|ESR (Mt CO2-equiv/yr)"] 
-  eea.emi.esr <- readSource("EEA_EuropeanEnvironmentAgency", subtype="ESR")[,,"Emi|GHG|ESR (Mt CO2-equiv/yr)"] 
+  # eea.emi.esr <- readSource("EEA_EuropeanEnvironmentAgency", subtype="sectoral")[,,"Emi|GHG|ESR (Mt CO2-equiv/yr)"]
+  eea.emi.esr <- readSource("EEA_EuropeanEnvironmentAgency", subtype = "ESR")[, , "Emi|GHG|ESR (Mt CO2-equiv/yr)"]
   eea.emi.esr[is.na(eea.emi.esr)] <- 0
-  
-  #Possible sources for 1990 emissions 
-  #(1) Table ES. 3GHG emissions in million tonnes CO2equivalent (excl. LULUCF)
+
+  # Possible sources for 1990 emissions
+  # (1) Table ES. 3GHG emissions in million tonnes CO2equivalent (excl. LULUCF)
   # https://www.eea.europa.eu//publications/european-union-greenhouse-gas-inventory-2020
-  #eea.emi.total_no_lulucf <- 5658.7 #CO2 emissions include indirect CO2
-  #eea.emi.total <- 5413 #Total (with net CO2 emissions/removals)
+  # eea.emi.total_no_lulucf <- 5658.7 #CO2 emissions include indirect CO2
+  # eea.emi.total <- 5413 #Total (with net CO2 emissions/removals)
   # (2) EEA_EuropeanEnvironmentAgency
-  #eea.emi.total <- readSource("EEA_EuropeanEnvironmentAgency", subtype="total") # it possibly includes more than ETS + ESR (bunkers? and lulucf?) # eea.emi.total[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"] (total EU 1990 -> 5721.371)
+  # eea.emi.total <- readSource("EEA_EuropeanEnvironmentAgency", subtype="total") # it possibly includes more than ETS + ESR (bunkers? and lulucf?) # eea.emi.total[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"] (total EU 1990 -> 5721.371)
   # (3) EuropeanEnergyDatasheets
-  eea.emi.total_EEA <- readSource("EuropeanEnergyDatasheets") # it matches the EEA sectoral, so it should include only ETS + ESR, however it is the closest one to the CRF values for 1990, source 1 (total EU 1990 -> 5652.164), so it is being used as the default for now
+  eea.emi.total_EEA <- readSource("EuropeanEnergyDatasheets", subtype = "EU28") # it matches the EEA sectoral, so it should include only ETS + ESR, however it is the closest one to the CRF values for 1990, source 1 (total EU 1990 -> 5652.164), so it is being used as the default for now
   # (4) EEA_sectoral, data only from 2005 onward
-  #eea.emi.total_EEA <- setNames(eea.emi.ets + eea.emi.esr, "Emi|GHGtot without Bunkers and LULUCF (Mt CO2-equiv/yr)") 
-  
+  # eea.emi.total_EEA <- setNames(eea.emi.ets + eea.emi.esr, "Emi|GHGtot without Bunkers and LULUCF (Mt CO2-equiv/yr)")
+
   # ETS + ESR emission target reduction in relation to 1990 = 40% reduction by 2030
-  
-  
+
+
   out <- NULL
   out <- mbind(out,
-               setNames(setYears(eea.emi.total_EEA[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"]*(1-0.40),2030), "Emi|GHGtot|target|40% (Mt CO2-equiv/yr)"), # target without lulucf
-               setNames(setYears(eea.emi.total_EEA[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"]*(1-0.55),2030), "Emi|GHGtot|target|55% (Mt CO2-equiv/yr)"), # target without lulucf
-               setNames(setYears(eea.emi.total_EEA[,1990,"Emi|GHGtot (Mt CO2-equiv/yr)"]*(1-0.65),2030), "Emi|GHGtot|target|65% (Mt CO2-equiv/yr)")  # target without lulucf
+               setNames(setYears(eea.emi.total_EEA[, 1990, "Emi|GHGtot (Mt CO2-equiv/yr)"] * (1 - 0.40), 2030), "Emi|GHGtot|target|40% (Mt CO2-equiv/yr)"), # target without lulucf
+               setNames(setYears(eea.emi.total_EEA[, 1990, "Emi|GHGtot (Mt CO2-equiv/yr)"] * (1 - 0.55), 2030), "Emi|GHGtot|target|55% (Mt CO2-equiv/yr)"), # target without lulucf
+               setNames(setYears(eea.emi.total_EEA[, 1990, "Emi|GHGtot (Mt CO2-equiv/yr)"] * (1 - 0.65), 2030), "Emi|GHGtot|target|65% (Mt CO2-equiv/yr)")  # target without lulucf
                )
-  
+
   # ESR emission target - per country ESR reduction target for 2030 = reduction of 40% by 2030 compared to 2005
-  esr_target_perc <- readSource("Eurostat_EffortSharing",subtype="target")
-  esr_target <- setYears(eea.emi.esr[,2005,],NULL)*(1+esr_target_perc)
-  esr_target[esr_target==0] <- NA
+  esr_target_perc <- readSource("Eurostat_EffortSharing", subtype = "target")
+  esr_target <- setYears(eea.emi.esr[, 2005, ], NULL) * (1 + esr_target_perc)
+  esr_target[esr_target == 0] <- NA
   out <- mbind(out,
-               setNames(esr_target[,2030,], "Emi|GHG|ESR|target|40% (Mt CO2-equiv/yr)")
+               setNames(esr_target[, 2030, ], "Emi|GHG|ESR|target|40% (Mt CO2-equiv/yr)")
   )
-  
+
   # ETS emission target (reduction of 2030 emissions by 61% compared to 2005)
-  ets_target <- setYears(eea.emi.ets[,2005,]*(1-0.61),2030)
-  ets_target[ets_target==0] <- NA
+  ets_target <- setYears(eea.emi.ets[, 2005, ] * (1 - 0.61), 2030)
+  ets_target[ets_target == 0] <- NA
   out <- mbind(out,
                setNames(ets_target, "Emi|GHG|ETS|target|61% (Mt CO2-equiv/yr)")
   )
-  
-  return(list(x=out,weight=NULL,unit="Mt CO2-equiv/yr",description="Emission reduction targets"))
+
+  return(list(x = out, weight = NULL, unit = "Mt CO2-equiv/yr", description = "Emission reduction targets"))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.99.0**
+R package **mrremind**, version **0.100.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.99.0.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.100.1.
 
 A BibTeX entry for LaTeX users is
 

--- a/man/calcEmiReference.Rd
+++ b/man/calcEmiReference.Rd
@@ -13,8 +13,7 @@ calcEmiReference()
 provides European 2030 emission targets in relation to 1990 and 2005 emissions
 }
 \examples{
-
-\dontrun{ 
+\dontrun{
 calcOutput("EmiReference")
 }
 


### PR DESCRIPTION
input generation failed due:
```
~~ Run readSource(type = "EuropeanEnergyDatasheets")
Error in subtype %in% c("EU27", "EU28") : 
 argument "subtype" is missing, with no default
 ```
 Therefore, subtype added in `R/calcEmiReference.R`. Additionally, replaced some getRegions by getItems to avoid linter warnings, and autoFormat.