### PR TITLE
Revert "Dev/industry specific material demand"

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '22104960'
+ValidationKey: '21912100'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.116.0",
+  "version": "0.115.0",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.116.0
-Date: 2022-03-05
+Version: 0.115.0
+Date: 2022-03-03
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -13,8 +13,7 @@
 #' @importFrom tidyr extract complete nesting replace_na crossing unite 
 #'   pivot_longer pivot_wider separate
 #' @importFrom readr read_delim
-#' @importFrom quitte seq_range interpolate_missing_periods character.data.frame
-#'   cartesian 
+#' @importFrom quitte seq_range interpolate_missing_periods character.data.frame cartesian
 #' @importFrom magclass mselect getItems getItems<-
 #' @author Antoine Levesque
 calcFEdemand <- function(subtype = "FE") {
@@ -730,279 +729,41 @@ calcFEdemand <- function(subtype = "FE") {
                  aggregate = FALSE,
                  years = getYears(reminditems), supplementary = FALSE)
     )
-    
-    ## re-curve specific industry activity per unit GDP ----
-    GDP <- calcOutput(type = 'GDP', FiveYearSteps = FALSE, 
-                      years = getYears(reminditems), aggregate = FALSE,
-                      supplementary = FALSE) %>% 
-      as.data.frame() %>% 
-      as_tibble() %>% 
-      select(iso3c = 'Region', year = 'Year', scenario = 'Data1', 
-             GDP = 'Value') %>% 
-      character.data.frame() %>% 
-      mutate(year = as.integer(.data$year))
-    
-    ### fix missing GDP numbers ----
-    # (see https://github.com/pik-piam/mrdrivers/issues/40)
-    if (any(0 == GDP$GDP)) {
-      GDP_fuckup_point <- GDP %>% 
-        filter(0 == .data$GDP) %>% 
-        group_by(!!!syms(c('iso3c', 'scenario'))) %>% 
-        filter(min(.data$year) == .data$year) %>% 
-        ungroup()
-      
-      GDP_replacement_scenario <- setdiff(
-        unique(GDP$scenario),
-        
-        GDP_fuckup_point %>% 
-          pull('scenario') %>% 
-          unique()
-      ) %>% 
-        first()
-      
-      GDP_fuckup_point <- GDP_fuckup_point %>% 
-        group_by(!!!syms(c('iso3c', 'scenario'))) %>% 
-        mutate(base.year = getYears(reminditems, TRUE) %>% 
-                 `[`(which(getYears(reminditems, TRUE) == !!sym('year')) - 1),
-               base.scenario = GDP_replacement_scenario) %>% 
-        ungroup() %>% 
-        select(-'GDP')
-      
-      GDP_replacement <- full_join(
-        GDP %>% 
-          semi_join(
-            GDP_fuckup_point,
-            
-            c('iso3c', 'scenario')
-          ) %>% 
-          left_join(
-            GDP_fuckup_point %>% 
-              select('iso3c', 'scenario', 'base.year'),
-            
-            c('iso3c', 'scenario')
-          ) %>% 
-          filter(.data$year >= .data$base.year) %>% 
-          select('iso3c', 'year', 'scenario', 'GDP'),
-        
-        GDP %>% 
-          semi_join(
-            GDP_fuckup_point,
-            
-            c('iso3c', scenario = 'base.scenario')
-          ) %>% 
-          left_join(
-            GDP_fuckup_point %>% 
-              select('iso3c', 'base.year', scenario = 'base.scenario') %>% 
-              distinct(),
-            
-            c('iso3c', 'scenario')
-          ) %>% 
-          filter(.data$year >= .data$base.year) %>% 
-          select(-'base.year') %>% 
-          group_by(!!!syms(c('iso3c', 'scenario'))) %>% 
-          mutate(factor = .data$GDP / lag(.data$GDP, default = first(.data$GDP),
-                                          order_by = .data$year)) %>% 
-          ungroup() %>% 
-          select('iso3c', 'year', 'factor'),
-        
-        c('iso3c', 'year')
-      ) %>% 
-        group_by(!!!syms(c('iso3c', 'scenario'))) %>% 
-        mutate(GDP = first(.data$GDP) * .data$factor) %>% 
-        ungroup() %>% 
-        select(all_of(colnames(GDP)))
-      
-      GDP <- bind_rows(
-        GDP %>% 
-          anti_join(
-            GDP_replacement, 
-            
-            c('iso3c', 'scenario', 'year')
-          ),
-        
-        GDP_replacement
-      ) %>% 
-        verify(expr = 0 < .data$GDP,
-               description = 'All GDP numbers > 0')
-    }
 
-    ### calculate specific material demand factors ----
-    foo <- full_join(
-      industry_subsectors_ue %>% 
-        as.data.frame() %>% 
-        as_tibble() %>% 
-        select(iso3c = 'Region', year = 'Year', scenario = 'Data1', 
-               subsector = 'Data2', value = 'Value') %>% 
-        character.data.frame() %>% 
-        mutate(year = as.integer(.data$year)),
-      
-       GDP,
-      
-      c('iso3c', 'year', 'scenario')
-    ) %>% 
-      assert(not_na, everything())
+    ### extend to SSP2_lowEn ----
+    # SSP2_lowEn is described as "per capita energy demands similar to SDP, also
+    # tech assumptions as in SDP".
+    # But population is lower in SDP than in SSP2, per-capita energy demands are
+    # higher.  So we apply an addition scaling factor (1 - b)^t with b linearly
+    # converging from a to a/2 over 150 years (end of model horizon).
+    a <- 0.01
+    factor_a <- tibble(year = getYears(industry_subsectors_ue, 
+                                       as.integer = TRUE)) %>% 
+      mutate(
+        x = pmax(0, .data$year - 2020),
+        factor = (1 - (a - (a / 300) * .data$x)) ^ .data$x) %>% 
+      select('year', 'factor') %>% 
+      as.magpie(temporal = 1, spatial = 0, data = 2) %>% 
+      dimSums()
     
-    industry_subsectors_material_alpha <- tribble(
-      ~scenario,            ~subsector, ~alpha,
-      'gdp_SSP1',           'cement',            0.03,
-      'gdp_SSP1',           'chemicals',         0.05,
-      'gdp_SSP1',           'steel_primary',     0.06,
-      'gdp_SSP1',           'steel_secondary',   0.06,
-      'gdp_SSP1',           'otherInd',          0.02,
-      'gdp_SSP2_lowEn',   'cement',            0.03,
-      'gdp_SSP2_lowEn',   'chemicals',         0.05,
-      'gdp_SSP2_lowEn',   'steel_primary',     0.06,
-      'gdp_SSP2_lowEn',   'steel_secondary',   0.06,
-      'gdp_SSP2_lowEn',   'otherInd',          0.02) %>% 
-      mutate(subsector = paste0('ue_', .data$subsector))
+    foo_pop <- calcOutput('Population', aggregate = FALSE, FiveYearSteps = FALSE)
     
-    industry_subsectors_material_relative <- tribble(
-      ~scenario,      ~base,          ~subsector,         ~factor,
-      'gdp_SDP',      'gdp_SSP1',     'cement',            1,
-      'gdp_SDP',      'gdp_SSP1',     'chemicals',         1,
-      'gdp_SDP',      'gdp_SSP1',     'steel_primary',     1,
-      'gdp_SDP',      'gdp_SSP1',     'steel_secondary',   1,
-      'gdp_SDP',      'gdp_SSP1',     'otherInd',          1,
-      'gdp_SDP_EI',   'gdp_SSP1',     'cement',            0.9,
-      'gdp_SDP_EI',   'gdp_SSP1',     'chemicals',         0.9,
-      'gdp_SDP_EI',   'gdp_SSP1',     'steel_primary',     0.9,
-      'gdp_SDP_EI',   'gdp_SSP1',     'steel_secondary',   0.9,
-      'gdp_SDP_EI',   'gdp_SSP1',     'otherInd',          0.9,
-      'gdp_SDP_MC',   'gdp_SSP1',     'cement',            0.85,
-      'gdp_SDP_MC',   'gdp_SSP1',     'chemicals',         0.85,
-      'gdp_SDP_MC',   'gdp_SSP1',     'steel_primary',     0.85,
-      'gdp_SDP_MC',   'gdp_SSP1',     'steel_secondary',   0.85,
-      'gdp_SDP_MC',   'gdp_SSP1',     'otherInd',          0.85,
-      'gdp_SDP_RC',   'gdp_SSP1',     'cement',            1.1,
-      'gdp_SDP_RC',   'gdp_SSP1',     'chemicals',         1.1,
-      'gdp_SDP_RC',   'gdp_SSP1',     'steel_primary',     1.1,
-      'gdp_SDP_RC',   'gdp_SSP1',     'steel_secondary',   1.1,
-      'gdp_SDP_RC',   'gdp_SSP1',     'otherInd',          1.1,
-      'gdp_SSP2',     'gdp_SSP2EU',   'cement',            1,
-      'gdp_SSP2',     'gdp_SSP2EU',   'chemicals',         1,
-      'gdp_SSP2',     'gdp_SSP2EU',   'steel_primary',     1,
-      'gdp_SSP2',     'gdp_SSP2EU',   'steel_secondary',   1,
-      'gdp_SSP2',     'gdp_SSP2EU',   'otherInd',          1,
-      'gdp_SSP3',     'gdp_SSP2EU',   'cement',            1,
-      'gdp_SSP3',     'gdp_SSP2EU',   'chemicals',         1,
-      'gdp_SSP3',     'gdp_SSP2EU',   'steel_primary',     1,
-      'gdp_SSP3',     'gdp_SSP2EU',   'steel_secondary',   1,
-      'gdp_SSP3',     'gdp_SSP2EU',   'otherInd',          1,
-      'gdp_SSP4',     'gdp_SSP2EU',   'cement',            1,
-      'gdp_SSP4',     'gdp_SSP2EU',   'chemicals',         1,
-      'gdp_SSP4',     'gdp_SSP2EU',   'steel_primary',     1,
-      'gdp_SSP4',     'gdp_SSP2EU',   'steel_secondary',   1,
-      'gdp_SSP4',     'gdp_SSP2EU',   'otherInd',          1) %>% 
-      mutate(subsector = paste0('ue_', .data$subsector))
+    industry_subsectors_ue_SSP2_lowEn <- (
+        dimSums(industry_subsectors_ue[,,'gdp_SDP'], dim = 3.1)
+      / dimSums(foo_pop[,getYears(industry_subsectors_ue),'pop_SDP'])
+      * dimSums(foo_pop[,getYears(industry_subsectors_ue),'pop_SSP2'])
+      * factor_a)
     
-    industry_subsectors_material_relative_change <- tribble(
-      ~scenario,    ~base.scenario,   ~subsector,         ~factor,
-      'gdp_SSP5',   'gdp_SSP2EU',    'cement',            0.5,
-      'gdp_SSP5',   'gdp_SSP2EU',    'chemicals',         0.5,
-      'gdp_SSP5',   'gdp_SSP2EU',    'steel_primary',     0.5,
-      'gdp_SSP5',   'gdp_SSP2EU',    'steel_secondary',   0.5,
-      'gdp_SSP5',   'gdp_SSP2EU',    'otherInd',          0.5) %>% 
-      mutate(subsector = paste0('ue_', .data$subsector))
+    getNames(industry_subsectors_ue_SSP2_lowEn) <- paste(
+      'gdp_SSP2_lowEn', getNames(industry_subsectors_ue_SSP2_lowEn), sep = '.')
     
-    
-    foo2 <- bind_rows(
-      # SSP2EU is the default scenario
-      foo %>% 
-        filter('gdp_SSP2EU' == .data$scenario),
-      
-      # these scenarios are pegged to SSP2EU
-      industry_subsectors_material_alpha %>% 
-        full_join(
-          foo %>% 
-            filter('gdp_SSP2EU' == .data$scenario) %>% 
-            group_by(!!!syms(c('subsector', 'iso3c', 'year'))) %>% 
-            summarise(specific.production = .data$value / .data$GDP, 
-                      .groups = 'drop'),
-          
-          'subsector'
-        ) %>% 
-        group_by(!!!syms(c('scenario', 'subsector', 'iso3c'))) %>% 
-        mutate(specific.production = ifelse(
-          2015 >= .data$year,
-          .data$specific.production,
-          ( .data$specific.production[2015 == .data$year]
-            * pmin(1, (1 - .data$alpha) ^ (.data$year - 2015))
-          ))) %>% 
-        ungroup() %>% 
-        left_join(
-          bind_rows(
-            foo, 
-            
-            
-            foo %>% 
-              filter('gdp_SSP2EU' == .data$scenario) %>% 
-              mutate(scenario = 'gdp_SSP2_lowEn')
-          ),
-          
-          c('scenario', 'subsector', 'iso3c', 'year')
-        ) %>% 
-        mutate(value = .data$specific.production * .data$GDP) %>% 
-        select(all_of(colnames(foo))) %>% 
-        assert(not_na, everything())
+    industry_subsectors_ue <- mbind(
+      industry_subsectors_ue,
+      industry_subsectors_ue_SSP2_lowEn
     )
     
+    rm(foo_pop, industry_subsectors_ue_SSP2_lowEn)
     
-    foo3 <- bind_rows(
-      foo2,
-      
-      industry_subsectors_material_relative %>% 
-        left_join(
-          foo2 %>% 
-            mutate(specific.production = .data$value / .data$GDP) %>% 
-            select(base = 'scenario', 'subsector', 'iso3c', 'year', 
-                   'specific.production'),
-          
-          c('base', 'subsector')
-        ) %>% 
-        left_join(
-          foo %>% 
-            select('scenario', 'subsector', 'iso3c', 'year', 'GDP'),
-          
-          c('scenario', 'subsector', 'iso3c', 'year')
-        ) %>% 
-        assert(not_na, everything()) %>% 
-        mutate(value = .data$specific.production * .data$GDP) %>% 
-        select(all_of(colnames(foo))),
-      
-      full_join(
-        industry_subsectors_material_relative_change,
-        
-        foo %>% 
-          semi_join(
-            industry_subsectors_material_relative_change,
-            
-            c('scenario' = 'base.scenario', 'subsector')
-          ),
-        
-        c('base.scenario' = 'scenario', 'subsector')
-      ) %>% 
-        select('scenario', 'iso3c', 'subsector', 'year', 'value', 'GDP', 
-               'factor') %>%
-        group_by(!!!syms(c('scenario', 'iso3c', 'subsector'))) %>% 
-        mutate(specific.production = .data$value / .data$GDP,
-               change = ifelse(2015 >= .data$year,
-                               1, 
-                               ( ( .data$specific.production 
-                                 / .data$specific.production[2015 == .data$year]
-                                 )
-                               * .data$factor
-                               )),
-               change = ifelse(is.finite(.data$change), .data$change, 1),
-               specific.production = .data$specific.production * .data$change,
-               value = .data$specific.production * .data$GDP) %>% 
-        ungroup() %>% 
-        select('scenario', 'iso3c', 'subsector', 'year', 'value', 'GDP')
-    )
-    
-    industry_subsectors_ue <- foo3 %>% 
-      select('iso3c', 'year', 'scenario', pf = 'subsector', 'value') %>% 
-      as.magpie(spatial = 1, temporal = 2, data = ncol(.))
-
     ## subsector FE shares ----
     . <- NULL
     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.115.0.9003**
+R package **mrremind**, version **0.115.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.115.0.9003.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.115.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,6 +47,6 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Krekeler},
   year = {2022},
-  note = {R package version 0.115.0.9003},
+  note = {R package version 0.115.0},
 }
 ```


### PR DESCRIPTION
Reverts pik-piam/mrremind#221, which breaks the calibration for all but SSP2 scenarios.