### PR TITLE
Included monitor function call to avoid input data preparation issues.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '23525640'
+ValidationKey: '23547188'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.123.3",
+  "version": "0.123.4",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.123.3
-Date: 2022-03-29
+Version: 0.123.4
+Date: 2022-03-31
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/calcEDGETrData.R
+++ b/R/calcEDGETrData.R
@@ -14,15 +14,17 @@
 #' @importFrom tidyr expand_grid
 
 calcEDGETrData <- function() {
-  
+
+  "!# @monitor edgeTransport:::generateEDGEdata"
+
   allscens <- bind_rows(
     ## for all "default" SSP variants we ship the whole zoo of EDGE-T scenarios
     expand_grid(
       SSP_scen = c("SSP1", "SSP2", "SSP5", "SSP2EU", "SDP"),
-      tech_scen = c("ConvCase", "ElecEra", "HydrHype", 
+      tech_scen = c("ConvCase", "ElecEra", "HydrHype",
                     "Mix", "Mix1", "Mix2", "Mix3", "Mix4"),
       smartlifestyle = 'FALSE'),
-    
+
     ## SHAPE scenarios are coupled to specific technologies
     tribble(
       ~SSP_scen,   ~tech_scen,   ~smartlifestyle,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.123.3**
+R package **mrremind**, version **0.123.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.123.3, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.123.4, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Krekeler},
   year = {2022},
-  note = {R package version 0.123.3},
+  note = {R package version 0.123.4},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This PR should (partially) tackle the problem with the input data generation not getting `generateEDGEdata`.

As @tscheypidi points out, `generateEDGEdata`  calls to calcOutput. The control flag option does not solve the problem completely as the monitor-flag will not check upon the underlying Calc functions:
the issue with a structure `calcSomething` -> `generateEDGEdata` -> `calcSomethingElse` is, that the dependency tree function will not be able to find the dependency on `calcSomethingElse` and therefor ignore it (and also ignore changes in it).

In the future, if all EDGE-T will be moved to a `read`-`convert`-`calc` scheme, the `monitor` call will not be necessary.

@Loisel and @johannah-pik , this hotfix should allow the input data generation to work.