### PR TITLE
have generateEDGEdata() and all contributing functions tracked by madrat

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '23609382'
+ValidationKey: '23667880'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.123.7",
+  "version": "0.124.0",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.123.7
-Date: 2022-04-04
+Version: 0.124.0
+Date: 2022-04-05
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/calcEDGETrData.R
+++ b/R/calcEDGETrData.R
@@ -40,12 +40,16 @@ calcEDGETrData <- function() {
   ## run EDGE-T
   EDGETdata = lapply(allscens,
     function(x) {
-      generateEDGEdata(input_folder = paste0(getConfig("sourcefolder"), "/EDGE-T_standalone/"),
-                       output_folder = NULL,
-                       SSP_scen = x[1],
-                       tech_scen = x[2],
-                       smartlifestyle = x[3],
-                       storeRDS = FALSE)
+      calcOutput(type = 'generateEDGEdata',
+                 aggregate = FALSE,
+                 supplementary = FALSE,
+                 input_folder = paste0(getConfig("sourcefolder"),
+                                       "/EDGE-T_standalone/"),
+                 output_folder = NULL,
+                 SSP_scen = x[1],
+                 tech_scen = x[2],
+                 smartlifestyle = x[3],
+                 storeRDS = FALSE)
     })
 
   return(list(x = EDGETdata,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.123.7**
+R package **mrremind**, version **0.124.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.123.7, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.124.0, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Krekeler},
   year = {2022},
-  note = {R package version 0.123.7},
+  note = {R package version 0.124.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
- modify `calcEDGETrData()` to call `calcOutput('generateEDGEData')` to make use of caching for `edgeTransport`
- see merge request pik-piam/edgeTransport#124