### PR TITLE
SDPs re-included, deprecated scenarios removed.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '23919770'
+ValidationKey: '23938860'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.125.3",
+  "version": "0.125.4",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.125.3
+Version: 0.125.4
 Date: 2022-04-08
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcEDGETrData.R
+++ b/R/calcEDGETrData.R
@@ -43,15 +43,15 @@ calcEDGETrData <- function() {
     ## for all "default" SSP variants we ship the whole zoo of EDGE-T scenarios
     expand_grid(
       SSP_scen = c("SSP1", "SSP2", "SSP5", "SSP2EU", "SDP"),
-      tech_scen = c("ConvCase", "ElecEra", "HydrHype",
-                    "Mix", "Mix1", "Mix2", "Mix3", "Mix4"),
-      smartlifestyle = 'FALSE')
+      tech_scen = c("Mix1", "Mix2", "Mix3", "Mix4"),
+      smartlifestyle = 'FALSE'),
+
     ## SHAPE scenarios are coupled to specific technologies
-    ## tribble(
-    ##   ~SSP_scen,   ~tech_scen,   ~smartlifestyle,
-    ##   'SDP_EI',    'Mix4',    'FALSE',
-    ##   'SDP_MC',    'Mix4',    'FALSE',
-    ##   'SDP_RC',    'Mix3',    'FALSE')
+    tribble(
+      ~SSP_scen,   ~tech_scen,   ~smartlifestyle,
+      'SDP_EI',    'Mix4',    'FALSE',
+      'SDP_MC',    'Mix4',    'FALSE',
+      'SDP_RC',    'Mix3',    'FALSE')
   )
 
   # generate list from data frame rows

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.125.3**
+R package **mrremind**, version **0.125.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.125.3, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.125.4, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Krekeler},
   year = {2022},
-  note = {R package version 0.125.3},
+  note = {R package version 0.125.4},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Now that https://github.com/pik-piam/edgeTransport/commit/71f6ee4ab4616a9e6492c4b3f1dc07abe6b967c1 is merged, SDPs can be reintegrated.