### PR TITLE
Use new emulators for SSP2 and SSP2EU

### DIFF
--- a/R/calcBiomassPrices.R
+++ b/R/calcBiomassPrices.R
@@ -18,10 +18,10 @@ calcBiomassPrices <- function(){
   getNames(xSSP2EU) <- gsub("SSP2", "SSP2EU", getNames(xSSP2EU))
   x <- mbind(x, xSSP2EU)
   # Replace scenarios with nocc with the respective RCPs, do the old scenarios separately
-  getNames(x) <- gsub("NDC-nocc-PkBudg500","rcp20",getNames(x)) 
-  getNames(x) <- gsub("NDC-nocc-PkBudg1150","rcp26",getNames(x))
-  getNames(x) <- gsub("NDC-nocc-NDC","rcp45",getNames(x))
-  getNames(x) <- gsub("NPI-nocc-Base","none",getNames(x))
+  getNames(x) <- gsub("NDC-nocc-PkBudg500","rcp20", getNames(x)) 
+  getNames(x) <- gsub("NDC-nocc-PkBudg1150","rcp26", getNames(x))
+  getNames(x) <- gsub("NDC-nocc-NDC","rcp45", getNames(x))
+  getNames(x) <- gsub("NPI-nocc-Base","none", getNames(x))
   # Remove unused nocc scenarios
   x <- x[,,!grepl("nocc", getNames(x))]
 

--- a/R/calcBiomassPrices.R
+++ b/R/calcBiomassPrices.R
@@ -9,6 +9,24 @@ calcBiomassPrices <- function(){
   x <- readSource("MAgPIE", subtype = "supplyCurve_magpie_40")
 
   # rename the rcp-scenarios
+  # New scenarios (MAgPIE4.4.0), include nocc because climate change impacts are on by default)
+  # TODO: Fix here when we have new emulators for other SSPs, currently only for SSP2
+  # Remove all old SSP2 and SSP2EU scenarios # TODO: There's probably no need to read them in readMAgPIE in the first place
+  x <- x[,,!(grepl("SSP2", getNames(x))&!grepl("nocc", getNames(x)))]
+  # Copy SSP2 into SSP2EU
+  xSSP2EU <- x[, , grepl("SSP2", getNames(x))]
+  getNames(xSSP2EU) <- gsub("SSP2", "SSP2EU", getNames(xSSP2EU))
+  x <- mbind(x, xSSP2EU)
+  # Replace scenarios with nocc with the respective RCPs, do the old scenarios separately
+  getNames(x) <- gsub("NDC-nocc-PkBudg500","rcp20",getNames(x)) 
+  getNames(x) <- gsub("NDC-nocc-PkBudg1150","rcp26",getNames(x))
+  getNames(x) <- gsub("NDC-nocc-NDC","rcp45",getNames(x))
+  getNames(x) <- gsub("NPI-nocc-Base","none",getNames(x))
+  # Remove unused nocc scenarios
+  x <- x[,,!grepl("nocc", getNames(x))]
+
+
+  # Old scenarios (MAgPIE <4.4.0), still using old budgets, TODO: replace as soon as we have new emulators
   getNames(x) <- gsub("NDC-PkBudg900","rcp20",getNames(x))
   getNames(x) <- gsub("NDC-PkBudg1300","rcp26",getNames(x))
   getNames(x) <- gsub("NDC-NDC","rcp45",getNames(x))


### PR DESCRIPTION
This PR replaces the MAgPIE emulators for SSP2 with new ones made with MAgPIE 4.4.0. It depends on [this PR in mrcommons](https://github.com/pik-piam/mrcommons/pull/55) that reads the new emulator files. These new emulators substantially speed up convergence in coupled REMIND-MAgPIE runs. 

The new scenarios scenarios have `-nocc-` in the name, reflecting the new configuration in MAgPIE that turns climate change impacts off (they are on by default in this version). The changes in `calcBiomassPrices` here replace just the data for SSP2 with the new scenario, leaving the emulators for other SSPs unchanged, taking advantage of this difference in naming. This is a temporary workaround before we have updated emulators for all SSPs.

The calibration runs for the new emulators can be found here /p/projects/htc/MagpieEmulator/magpie440_2022-04-08 , with the flat fit replacement scripts and diagnostic plots for each scenario in output/emulator.

The mapping between REMIND scenarios and RCPs for SSP2 and SSP2EU is as follows:

| MAgPIE configuration and REMIND scenario | RCP    |
|------------------------------------------|--------|
| NDC-nocc-PkBudg500                       | RCP2.0 |
| NDC-nocc-PkBudg1150                      | RCP2.6 |
| NDC-nocc-NDC                             | RCP4.5 |
| NPI-nocc-Base                            | none   |


Comparable runs with the new and old emulators can be found in `/p/projects/piam/abrahao/scratch/emulators`, both standalone and coupled.

The results for standalone REMIND are not substantially changed, except for a slighltly higher reliance on bioenergy in late timesteps. `compareScenarios` for standalone runs can be found in the `remind-new` folder. 

Tagging @dklein-pik since I can't assign reviewers yet. @LaviniaBaumstark might also want to take a look at the compareSenarios since we're in the middle of the validation.