### PR TITLE
add data.frame to avoid quitte warning

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '24715960'
+ValidationKey: '24742848'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.129.2",
+  "version": "0.129.3",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.129.2
-Date: 2022-05-18
+Version: 0.129.3
+Date: 2022-05-24
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/toolBiomassSupplyAggregate.R
+++ b/R/toolBiomassSupplyAggregate.R
@@ -1,72 +1,71 @@
 #' toolBiomassSupplyAggregate
-#' The function aggregates biomass supply curves to regionmapping different from H12. 
-#' It only works if all regions are subregions of H12 regions. The offset parameter (a) is taken from the H12 region. 
+#' The function aggregates biomass supply curves to regionmapping different from H12.
+#' It only works if all regions are subregions of H12 regions. The offset parameter (a) is taken from the H12 region.
 #' The slope parameter (b) is multiplied by a weight. The weight is the inverse of the share of agricultural area of the subregion in the H12 region.
-#' 
+#'
 #' @return return: returns region aggregated biomass supply curve data
-#' 
+#'
 #' @param x magclass object that should be aggregated
 #' @param rel relation matrix containing a region mapping.
 #' @param weight aggregation weight
 #' @author Felix Schreyer
 #' @export
 #' @importFrom magclass as.magpie dimReduce
-#' @importFrom dplyr %>% mutate select rename left_join 
-#' @importFrom quitte as.quitte 
-
-
+#' @importFrom dplyr %>% mutate select rename left_join
+#' @importFrom quitte as.quitte
 
 toolBiomassSupplyAggregate <- function(x, rel=NULL, weight = calcOutput("FAOLand", aggregate = F)[,,"6610",pmatch=TRUE][,"y2010",]){
-  
+
   # variable definitions needed for data.frame operations below
   region <- NULL
   value <- NULL
   Total <- NULL
   country <- NULL
-  
+
   # FS: aggregate from iso-countries to regions
   # inverse of the disaggregation described in convertMAgPIE.R (subytpe = "supplyCurve_magpie_40")
   # copy offset parameter a from iso-country to region
   # multiply agricultural land share of iso-country in region with iso-country slope parameter b for
   # one iso-country to obtain slope parameter b of region
-  
+
   # calculate share in agricultural land area of countries relative to MAgPIE regions
   # get agricultural land for iso-countries in 2010 from FAO
   AgrLandIso <- weight
   # aggregate agricultural land to regions in regionmapping
   AgrLandReg <- toolAggregate(AgrLandIso, rel)
-  
+
   # calculate share of agricultural land area for each iso-country relative to the MAgPIE region it is in
-  AgrLandShare <- as.quitte(AgrLandIso) %>% 
-    select(region, value) %>% 
-    rename(country = region) %>% 
-    left_join(rel) %>% 
-    left_join((as.quitte(AgrLandReg) %>% 
-                 select(region, value) %>% 
-                 rename(Total = value))) %>% 
+  AgrLandShare <- as.quitte(AgrLandIso) %>%
+    select(region, value) %>%
+    rename(country = region) %>%
+    left_join(rel) %>%
+    left_join((as.quitte(AgrLandReg) %>%
+                 select(region, value) %>%
+                 rename(Total = value))) %>%
     mutate(value = value / Total) %>%
     # if no agricultural area at all -> assume very low share of 1e-5
-    mutate( value = ifelse(value == 0, 1e-5, value)) %>% 
-    select(country, value) %>% 
-    as.magpie(spatial = 1, datacol=2) %>%  
+    mutate( value = ifelse(value == 0, 1e-5, value)) %>%
+    select(country, value) %>%
+    data.frame %>%
+    as.magpie(spatial = 1, datacol=2) %>%
     dimReduce()
-  
+
   # multiply slope parameter with agricultural land share
   x <- x
   x[,,"b"] <- x[,,"b"] * AgrLandShare
-  
-  # select one country per region (first country in alphabet) to set weight = 1, 
+
+  # select one country per region (first country in alphabet) to set weight = 1,
   # rest of countries weight 0
-  rel.sort <- rel %>% 
+  rel.sort <- rel %>%
                     arrange(region)
   iso.sel <- rel.sort$country[cumsum(table(rel.sort$region))]
-  
+
   weight <- new.magpie(getRegions(x), fill = 0)
   weight[iso.sel,,] <- 1
-  
-  # aggregate to regionmapping, take a and b value only of one country within the region, 
+
+  # aggregate to regionmapping, take a and b value only of one country within the region,
   # other weights are 0
   y <- toolAggregate(x, rel, weight = weight)
-  
+
   return(y)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.129.2**
+R package **mrremind**, version **0.129.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.129.2, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Krekeler R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.129.3, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Krekeler},
   year = {2022},
-  note = {R package version 0.129.2},
+  note = {R package version 0.129.3},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/man/toolBiomassSupplyAggregate.Rd
+++ b/man/toolBiomassSupplyAggregate.Rd
@@ -3,8 +3,8 @@
 \name{toolBiomassSupplyAggregate}
 \alias{toolBiomassSupplyAggregate}
 \title{toolBiomassSupplyAggregate
-The function aggregates biomass supply curves to regionmapping different from H12. 
-It only works if all regions are subregions of H12 regions. The offset parameter (a) is taken from the H12 region. 
+The function aggregates biomass supply curves to regionmapping different from H12.
+It only works if all regions are subregions of H12 regions. The offset parameter (a) is taken from the H12 region.
 The slope parameter (b) is multiplied by a weight. The weight is the inverse of the share of agricultural area of the subregion in the H12 region.}
 \usage{
 toolBiomassSupplyAggregate(
@@ -25,8 +25,8 @@ return: returns region aggregated biomass supply curve data
 }
 \description{
 toolBiomassSupplyAggregate
-The function aggregates biomass supply curves to regionmapping different from H12. 
-It only works if all regions are subregions of H12 regions. The offset parameter (a) is taken from the H12 region. 
+The function aggregates biomass supply curves to regionmapping different from H12.
+It only works if all regions are subregions of H12 regions. The offset parameter (a) is taken from the H12 region.
 The slope parameter (b) is multiplied by a weight. The weight is the inverse of the share of agricultural area of the subregion in the H12 region.
 }
 \author{


### PR DESCRIPTION
Avoids the following warning:
```
~ Input does not follow the full quitte class definition! Fallback to data.frame conversion.
```

To have a fix local test, run this. The first variant creates a warning, the second not.
```
library(madrat)
library(magclass)
library(mrremind)
library(dplyr)
library(quitte)
x <- readSource("MAgPIE", subtype = "supplyCurve_magpie_40")
weight <- calcOutput("FAOLand", aggregate = F)[,,"6610",pmatch=TRUE][,"y2010",]

AgrLandIso <- weight
AgrLandReg <- weight


AgrLandShare <- as.quitte(AgrLandIso) %>% 
    select(region, value) %>% 
    left_join((as.quitte(AgrLandReg) %>% 
                 select(region, value) %>% 
                 rename(Total = value))) %>% 
    rename(country = region) %>% 
    mutate(value = value / Total) %>%
    # if no agricultural area at all -> assume very low share of 1e-5
    mutate( value = ifelse(value == 0, 1e-5, value)) %>% 
    select(country, value) %>% 
    as.magpie(spatial = 1, datacol=2) %>%  
    dimReduce()

AgrLandShare2 <- as.quitte(AgrLandIso) %>% 
    select(region, value) %>% 
    left_join((as.quitte(AgrLandReg) %>% 
                 select(region, value) %>% 
                 rename(Total = value))) %>% 
    rename(country = region) %>% 
    mutate(value = value / Total) %>%
    # if no agricultural area at all -> assume very low share of 1e-5
    mutate( value = ifelse(value == 0, 1e-5, value)) %>% 
    select(country, value) %>%
    data.frame %>%
    as.magpie(spatial = 1, datacol=2) %>%  
    dimReduce()
```