### PR TITLE
fix bug in IEA data aggregation causing too low steel energy share

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '26487580'
+ValidationKey: '26508142'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.138.1",
+  "version": "0.138.2",
   "description": "<p>The mrremind packages contains data preprocessing for the REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrremind
 Type: Package
 Title: MadRat REMIND Input Data Package
-Version: 0.138.1
-Date: 2022-07-07
+Version: 0.138.2
+Date: 2022-07-08
 Authors@R: c(person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = c("aut","cre")),
              person("Renato", "Rodrigues", role = "aut"),
              person("Antoine", "Levesque", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -20,690 +20,690 @@
 #' @author Antoine Levesque
 calcFEdemand <- function(subtype = "FE") {
 
-  #----- Functions ------------------
-  getScens = function(mag) {
-    getNames(mag, dim = "scenario")
-  }
-
-  addDim <- function(x, addnm, dim, dimCode = 3.2) {
-    do.call("mbind", lapply(addnm, function(item) {
-      add_dimension(x, dim = dimCode, add = dim, nm = item)
-    }))
-  }
-
-  expand_vectors = function(x,y) {
-    if (is.data.frame(y)) {
-      y = apply(y,1,paste,collapse=".")
+    #----- Functions ------------------
+    getScens = function(mag) {
+      getNames(mag, dim = "scenario")
     }
 
-    paste(rep(x,each=length(y)),y,sep=".")
-  }
-
-  addSDP_transport <- function(rmnditem){
-    ## adding dummy vars and funcs to avoid global var complaints
-    scenario.item  <- year <- scenario <- item <- region <- value <- variable <- .SD  <- dem_cap  <- fact <- toadd <- Year <- gdp_cap <- ssp2dem <- window <- train_add <- NULL
-
-    ## start of actual function
-    trp_nodes <- c("ueelTt", "ueLDVt", "ueHDVt")
-
-    ## we work in the REMIND H12 regions to avoid strange ISO country behavior when rescaling
-    mappingfile <- toolGetMapping(type = "regional", name = "regionmappingH12.csv", returnPathOnly = TRUE)
-    rmnd_reg <- toolAggregate(rmnditem, mappingfile, from="CountryCode", to="RegionCode")
-
-    ## to data.table (we use gdp_SSP2 as a starting point)
-    rmndt <- as.data.table(rmnd_reg)
-    rmndt[, c("scenario", "item") := tstrsplit(scenario.item, ".", fixed = TRUE)][
-      , "scenario.item" := NULL][
-      , year := as.numeric(gsub("y", "", year))]
-    setnames(rmndt, "V3", "region", skip_absent = TRUE)
-    trpdem <- rmndt[item %in% trp_nodes & scenario == "gdp_SSP2"][, scenario := "gdp_SDP"]
-
-    ## get population
-    pop <- as.data.table(calcOutput("Population"))[
-      , year := as.numeric(gsub("y", "", year))]
-    setnames(pop, c("variable", 'iso3c'), c("scenario", 'region'),
-             skip_absent = TRUE)
-
-    ## intrapolate missing years
-    yrs <- sort(union(pop$year, trpdem$year))
-    pop <- pop[CJ(region=pop$region, year=yrs, scenario=pop$scenario, unique=T),
-               on=c("region", "year", "scenario")]
-    pop[, value := approx(x=.SD$year, y=.SD$value, xout=.SD$year)$y,
-        by=c("region", "scenario")]
-
-    ## merge scenario names
-    pop[, scenario := gsub("pop_", "gdp_", scenario)]
-    setnames(pop, "value", "pop")
-
-    demPop <- pop[trpdem, on=c("year", "region", "scenario")]
-    demPop[, dem_cap := value/pop * 1e3] # EJ/10^6=TJ (pop. in millions), scale to GJ/cap*yr
-
-    gdp_iso <- calcOutput("GDP", aggregate = F)[,, "gdp_SDP"]
-    gdp_iso <- time_interpolate(gdp_iso, getYears(rmnd_reg))
-    gdp_reg <- toolAggregate(gdp_iso, mappingfile, from="CountryCode", to="RegionCode")
-    getSets(gdp_reg) <- c("region", "Year", "scenario")
-    ## load GDP
-    gdp <- as.data.table(gdp_reg)[
-      , year := as.numeric(gsub("y", "", Year))][
-      , Year := NULL]
-
-    setnames(gdp, "value", "gdp")
-
-    ## merge
-    demPop <- gdp[demPop, on=c("year", "region", "scenario")]
-    demPop[, gdp_cap := gdp/pop]
-
-    ## add new scenario from SSP2
-    newdem <- demPop
-
-    setkey(newdem, "year", "item")
-    newdem[, ssp2dem := dem_cap]
-    for(yr in seq(2025, 2100, 5)){
-      it <- "ueLDVt"
-      target <- 7 ## GJ
-      switch_yrs <- 10
-      drive <- 0.12
-      prv_row <- newdem[year == yr - 5 & item == it]
-      newdem[year == yr & item == it,
-             window := ifelse(prv_row$dem_cap - target >= 0,
-                              drive * pmin((prv_row$dem_cap - target)^2/target^2, 0.2),
-                              -drive * (target - prv_row$dem_cap)/target)]
-
-      newdem[year == yr & item == it,
-             dem_cap := (1-window)^5 * prv_row$dem_cap * pmin((yr - 2020)/switch_yrs, 1) + ssp2dem * (1 - pmin((yr - 2020)/switch_yrs, 1))]
-
-      it <- "ueHDVt"
-      target <- 9
-      prv_row <- newdem[year == yr - 5 & item == it]
-      newdem[year == yr & item == it,
-             window := ifelse(prv_row$dem_cap - target >= 0,
-                              drive * pmin((prv_row$dem_cap - target)^2/target^2, 0.2),
-                              -drive * (target - prv_row$dem_cap)/target)]
-      newdem[year == yr & item == it,
-             dem_cap := (1-window)^5 * prv_row$dem_cap * pmin((yr - 2020)/switch_yrs, 1) + ssp2dem * (1 - pmin((yr - 2020)/switch_yrs, 1))]
-
+    addDim <- function(x, addnm, dim, dimCode = 3.2) {
+      do.call("mbind", lapply(addnm, function(item) {
+        add_dimension(x, dim = dimCode, add = dim, nm = item)
+      }))
     }
 
-    newdem[, c("window", "ssp2dem") := NULL]
-
-    ## toplot <- rbind(demPop, newdem)
-
-    ## ggplot(toplot[item == "ueHDVt" & region %in% c("CHN", "USA", "IND", "JPN") & scenario %in% c("gdp_SDP", "gdp_SSP2")], aes(x=year, y=dem_cap)) +
-    ##   geom_line(aes(color=scenario)) +
-    ##   facet_wrap(~region)
-
-    ## add trains
-    trns <- function(year){
-      if(year <= 2020)
-        return(0)
-      else
-        return((year-2020)^2 * 0.000018) # at 2100, this is ~ 11.5%
-    }
-
-    yrs <- unique(newdem$year)
-    trainsdt <- data.table(year=yrs, fact=sapply(yrs, trns))
-
-    newdem <- newdem[trainsdt, on="year"]
-
-    ## both freight and passenger road are reduced in favour of trains
-    newdem[item %in% c("ueHDVt", "ueLDVt"), toadd := dem_cap * fact]
-    newdem[item %in% c("ueHDVt", "ueLDVt"), dem_cap := dem_cap - toadd]
-
-    newdem[, train_add := 0]
-    newdem[item == "ueelTt" & year > 2025, dem_cap := newdem[item == "ueelTt" & year == 2025]$dem_cap, by=year]
-
-    ## we add it to trains
-    newdem[year > 2020, train_add := sum(toadd, na.rm = T),
-           by=c("year", "region")]
-    ## replace old values
-    newdem[item == "ueelTt", dem_cap := dem_cap + train_add][
-      , c("toadd", "train_add", "fact") := NULL]
-
-    ## ggplot(newdem[region %in% c("SSA", "USA", "IND", "JPN")], aes(x=year, y=dem_cap)) +
-    ##   geom_line(aes(color=item)) +
-    ##   facet_wrap(~region)
-
-    ## multiply by population
-    newdem[, value := dem_cap * pop / 1e3] # back to EJ
-
-    ## constant for t>2100
-    newdem[year > 2100, value := newdem[year == 2100]$value, by="year"]
-
-    ## ggplot(newdem[region %in% c("CHN", "USA", "IND", "JPN"), sum(dem_cap), by=.(year, region)], aes(x=year, y=V1)) +
-    ##   geom_line() +
-    ##   facet_wrap(~region)
-    newdem <- suppressWarnings(as.magpie(newdem[, c("region", "year", "scenario", "item", "value")]))
-    dem_iso <- toolAggregate(newdem, mappingfile, gdp_iso, from="RegionCode", to="CountryCode")
-    getSets(dem_iso)[1] <- "region"
-
-    return(dem_iso)
-
-  }
-
-  addSDP_industry <- function(reminditems) {
-    # Modify industry FE trajectories of SSP1 (and SSP2) to generate SDP
-    # scenario trajectories
-
-    # mask non-global variables so R doesn't get its panties twisted
-    year <- Year <- Data1 <- Data2 <- Region <- Value <- Data3 <- scenario <-
-      iso3c <- value <- variable <- pf <- FE <- VA <- GDP <- VApGDP <- FEpVA <-
-      gdp_SSP1 <- gdp_SSP2 <- f <- gdp_SDP <- .FE <- f.mod <- gdp <- pop <-
-      GDPpC <- item <- NULL
-
-    # output years
-    years <- as.integer(sub('^y', '', getYears(reminditems)))
-
-    tmp_GDPpC <- bind_rows(
-      # load GDP projections
-      tmp_GDP <- calcOutput('GDP', FiveYearSteps = FALSE,
-                            aggregate = FALSE) %>%
-        as.data.frame() %>%
-        as_tibble() %>%
-        character.data.frame() %>%
-        mutate(Year = as.integer(as.character(Year))) %>%
-        filter(grepl('^gdp_SSP[12]$', Data1),
-               Year %in% years) %>%
-        separate(col = 'Data1', into = c('variable', 'scenario'), sep = '_') %>%
-        select('scenario', iso3c = 'Region', year = 'Year', 'variable',
-               value = 'Value'),
-
-      tmp_pop <- calcOutput('Population', FiveYearSteps = FALSE,
-                            aggregate = FALSE) %>%
-        as.data.frame() %>%
-        as_tibble()  %>%
-        character.data.frame() %>%
-        mutate(Year = as.integer(as.character(Year))) %>%
-        filter(grepl('^pop_SSP[12]$', Data1),
-               Year %in% years) %>%
-        separate(col = 'Data1', into = c('variable', 'scenario'), sep = '_') %>%
-        select('scenario', iso3c = 'Region', year = 'Year', 'variable',
-               value = 'Value')
-    ) %>%
-      mutate(scenario = paste0('gdp_', scenario)) %>%
-      pivot_wider(names_from = 'variable') %>%
-      group_by(.data$scenario, .data$iso3c, .data$year) %>%
-      summarise(GDPpC = .data$gdp / .data$pop, .groups = 'drop')
-
-    # - for each country and scenario, compute a GDPpC-dependent specific energy
-    #   use reduction factor according to 3e-7 * GDPpC + 0.2 [%], which is
-    #   capped at 0.7 %
-    #   - the mean GDPpC of countries with GDPpC > 15000 (in 2015) is about 33k
-    #   - so efficiency gains range from 0.4 % at zero GDPpC (more development
-    #     leeway) to 1.4 % at 33k GDPpC (more stringent energy efficiency)
-    #   - percentage numbers are halved and applied twice, to VA/GDP and FE/VA
-    # - linearly reduce this reduction factor from 1 to 0 over the 2020-2150
-    #   interval
-    # - cumulate the reduction factor over the time horizon
-
-    SSA_countries <- read_delim(
-      file = toolGetMapping(type = 'regional', name = 'regionmappingH12.csv', returnPathOnly = TRUE),
-      delim = ';',
-      col_names = c('country', 'iso3c', 'region'),
-      col_types = 'ccc',
-      skip = 1) %>%
-      filter('SSA' == !!sym('region')) %>%
-      select(-'country', -'region') %>%
-      getElement('iso3c')
-
-    sgma <- 8e3
-    cutoff <- 1.018
-    epsilon <- 0.018
-    exp1 <- 3
-    exp2 <- 1.5
-
-    reduction_factor <- tmp_GDPpC %>%
-      interpolate_missing_periods(year = seq_range(range(year)),
-                                  value = 'GDPpC') %>%
-      group_by(scenario, iso3c) %>%
-      mutate(
-        # no reduction for SSA countries before 2050, to allow for more
-        # equitable industry and infrastructure development
-        f = cumprod(ifelse(2020 > year, 1, pmin(cutoff, 1 + 4*epsilon*((sgma/GDPpC)^exp1 - (sgma/GDPpC)^exp2))
-                           ))) %>%
-      ungroup() %>%
-      select(-GDPpC) %>%
-      filter(year %in% years)
-
-    bind_rows(
-      # select industry FE use
-      reminditems %>%
-        as.data.frame() %>%
-        as_tibble() %>%
-        mutate(Year = as.integer(as.character(Year))) %>%
-        filter(grepl('^gdp_SSP[12]$', Data1),
-               grepl('fe..i', Data2)) %>%
-        select(scenario = Data1, iso3c = Region, year = Year, variable = Data2,
-               value = Value) %>%
-        character.data.frame(),
-
-      # reuse GDP projections
-      tmp_GDP %>%
-        mutate(variable = 'GDP',
-               scenario = paste0('gdp_', scenario)),
-
-      # load VA projections
-      readSource('EDGE_Industry', 'projections_VA_iso3c', convert = FALSE) %>%
-        as.data.frame() %>%
-        as_tibble() %>%
-        select(scenario = Data1, iso3c = Region, year = Year, sector = Data2,
-               value = Value) %>%
-        filter(grepl('^gdp_SSP[12]$', scenario),
-               'Total' != iso3c,
-               as.character(year) %in% years) %>%
-        mutate(iso3c = as.character(iso3c),
-               year = as.integer(as.character(year))) %>%
-        group_by(scenario, iso3c, year) %>%
-        summarise(value = sum(value), .groups = 'drop') %>%
-        mutate(variable = 'VA') %>%
-        interpolate_missing_periods(year = years, expand.values = TRUE) %>%
-        character.data.frame()
-    ) %>%
-      spread(variable, value) %>%
-      gather(pf, FE, matches('^fe..i$')) %>%
-      inner_join(reduction_factor, c('scenario', 'iso3c', 'year')) %>%
-      mutate(VApGDP = VA  / GDP,
-             FEpVA  = FE  / VA) %>%
-      # Modify reduction factor f based on feeli share in pf
-      # f for feeli is sqrt of f; for for others choosen such that total
-      # reduction equals f
-      group_by(scenario, iso3c, year) %>%
-      mutate(f.mod = ifelse('feeli' == pf & f < 1, sqrt(f), f)) %>%
-      ungroup() %>%
-      select(-f, f = f.mod) %>%
-      # gather(variable, value, GDP, FE, VA, VApGDP, FEpVA) %>%
-      # SDP scenario is equal to SSP1 scenario, except for VA/GDP and FE/VA
-      # indicators, which are equal to the lower value of the SSP1 or SSP2
-      # scenario times the reduction factor f(t)
-      group_by(iso3c, year, pf) %>%
-      mutate(VApGDP = min(VApGDP) * f,
-             FEpVA  = min(FEpVA)  * f) %>%
-      ungroup() %>%
-      select(-f) %>%
-      filter('gdp_SSP2' != scenario) %>%
-      mutate(scenario = 'gdp_SDP') %>%
-      mutate(.FE = FEpVA * VApGDP * GDP,
-             value = ifelse(!is.na(.FE), .FE, FE)) %>%
-      select(scenario, iso3c, year, item = pf, value) %>%
-      # TODO: differentiate these scenarios if there is a applicable storyline
-      # for them
-      complete(nesting(iso3c, year, item, value),
-               scenario = paste0('gdp_SDP', c('', '_EI', '_MC', '_RC'))) %>%
-      select(scenario, iso3c, year, item, value) %>%
-      as.magpie() %>%
-      return()
-  }
-
-  #----- READ-IN DATA ------------------
-  if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings",
-                     "UE_buildings", "FE_for_Eff", "UE_for_Eff")) {
-
-    stationary <- readSource("EDGE",subtype="FE_stationary")
-    buildings  <- readSource("EDGE",subtype="FE_buildings")
-
-    # consider only fixed climate
-    if (subtype %in% c("FE_buildings", "UE_buildings")) {
-      rcps <- paste0("rcp", gsub("p", "", getItems(buildings, "rcp")))
-      rcps <- gsub("rcpfixed", "none", rcps)
-      getItems(buildings, "rcp") <- rcps
-      stationary <- addDim(stationary, rcps, "rcp")
-    } else {
-      rcps <- NULL
-      buildings <- mselect(buildings, rcp = "fixed", collapseNames = TRUE)
-    }
-
-    ## fix issue with trains in transport trajectories: they seem to be 0 for t>2100
-    if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings", "UE_buildings") &
-        all(mselect(stationary, year = "y2105", scenario = "SSP2", item = "feelt") == 0)) {
-      stationary[, seq(2105, 2150, 5), "feelt"] = time_interpolate(stationary[, 2100, "feelt"], seq(2105, 2150, 5))
-    }
-
-    ## common years
-
-    ## stationary year range is in line with requirements on the RMND side
-    fill_years <- setdiff(getYears(stationary),getYears(buildings))
-    buildings <- time_interpolate(buildings,interpolated_year = fill_years, integrate_interpolated_years = T, extrapolation_type = "constant")
-
-    y <- if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings", "UE_Buildings")) {
-      getYears(stationary)  # >= 1993
-    } else {
-      intersect(getYears(stationary), getYears(buildings))  # >= 2000
-    }
-
-    data <- mbind(stationary[, y, ], buildings[, y, ])
-
-    unit_out = "EJ"
-    description_out <- ifelse(subtype %in% c("FE_for_Eff", "UE_for_Eff"),
-      "demand pathways for useful/final energy in buildings and industry corresponding to the final energy items in REMIND",
-      "demand pathways for final energy in buildings and industry in the original file")
-  }
-
-  if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out")) {
-    # ---- _ modify Industry FE data to carry on current trends ----
-    v <- grep('\\.fe(..i$|ind)', getNames(data), value = TRUE)
-
-    dataInd <- data[,,v] %>%
-      as.quitte() %>%
-      as_tibble() %>%
-      select('scenario', 'iso3c' = 'region', 'pf' = 'item', 'year' = 'period',
-             'value') %>%
-      character.data.frame()
-
-    regionmapping <- toolGetMapping(type = 'regional',
-                                    name = 'regionmappingH12.csv') %>%
-      select(country = 'X', iso3c = 'CountryCode', region = 'RegionCode')
-
-    historic_trend <- c(2004, 2015)
-    phasein_period <- c(2015, 2050)
-    phasein_time   <- phasein_period[2] - phasein_period[1]
-
-    dataInd <- bind_rows(
-      dataInd %>%
-        filter(phasein_period[1] > !!sym('year')),
-      inner_join(
-        # calculate regional trend
-        dataInd %>%
-          # get trend period
-          filter(between(!!sym('year'), historic_trend[1], historic_trend[2]),
-                 0 != !!sym('value')) %>%
-          # sum regional totals
-          full_join(regionmapping %>% select(-!!sym('country')), 'iso3c') %>%
-          group_by(!!sym('scenario'), !!sym('region'), !!sym('pf'),
-                   !!sym('year')) %>%
-            summarise(value = sum(!!sym('value')), .groups = 'drop') %>%
-          # calculate average trend over trend period
-          interpolate_missing_periods(year = seq_range(historic_trend),
-                                      expand.values = TRUE) %>%
-          group_by(!!sym('scenario'), !!sym('region'), !!sym('pf')) %>%
-          summarise(trend = mean(!!sym('value') / lag(!!sym('value')),
-                                   na.rm = TRUE),
-                      .groups = 'drop') %>%
-          # only use negative trends (decreasing energy use)
-          mutate(trend = ifelse(!!sym('trend') < 1, !!sym('trend'), NA)),
-        # modify data projection
-        dataInd %>%
-          filter(phasein_period[1] <= !!sym('year')) %>%
-          interpolate_missing_periods(
-            year = phasein_period[1]:max(dataInd$year)) %>%
-          group_by(!!sym('scenario'), !!sym('iso3c'), !!sym('pf')) %>%
-          mutate(
-            growth = replace_na(!!sym('value') / lag(!!sym('value')), 1)) %>%
-          full_join(regionmapping %>% select(-'country'), 'iso3c'),
-        c('scenario', 'region', 'pf')) %>%
-      group_by(!!sym('scenario'), !!sym('iso3c'), !!sym('pf')) %>%
-      mutate(
-        # replace NA (positive) trends with end. growth rates -> no change
-        trend = ifelse(is.na(!!sym('trend')), !!sym('growth'),
-                       !!sym('trend')),
-        value_ = first(!!sym('value'))
-          * cumprod(
-            ifelse(
-              phasein_period[1] == !!sym('year'), 1,
-              ( !!sym('trend')
-              * pmax(0, phasein_period[2] - !!sym('year') + 1)
-              + !!sym('growth')
-              * pmin(phasein_time, !!sym('year') - phasein_period[1] - 1)
-              ) / phasein_time)),
-        value = ifelse(is.na(!!sym('value_')) | 0 == !!sym('value_'),
-                       !!sym('value'), !!sym('value_'))) %>%
-      ungroup() %>%
-      select(-'region', -'value_', -'trend', -'growth') %>%
-      filter(!!sym('year') %in% unique(dataInd$year))
-    ) %>%
-      rename('region' = 'iso3c', 'item' = 'pf') %>%
-      as.magpie()
-
-    data <- mbind(data[,,v, invert = TRUE], dataInd)
-
-    # ---- _ modify SSP1 Industry FE demand ----
-    # compute a reduction factor of 1 before 2021, 0.84 in 2050, and increasing
-    # to 0.78 in 2150
-    f <- as.integer(sub('^y', '', y)) - 2020
-    f[f < 0] <- 0
-    f <- 0.95 ^ pmax(0, log(f))
-
-    # get Industry FE items
-    v <- grep('^SSP1\\.fe(..i$|ind)', getNames(data), value = TRUE)
-
-    # apply changes
-    for (i in 1:length(y)) {
-      if (1 != f[i]) {
-        data[,y[i],v] <- data[,y[i],v] * f[i]
+    expand_vectors = function(x,y) {
+      if (is.data.frame(y)) {
+        y = apply(y,1,paste,collapse=".")
       }
+
+      paste(rep(x,each=length(y)),y,sep=".")
     }
 
-  } else if (subtype == "ES"){
-    Unit2Million = 1e-6
+    addSDP_transport <- function(rmnditem){
+      ## adding dummy vars and funcs to avoid global var complaints
+      scenario.item  <- year <- scenario <- item <- region <- value <- variable <- .SD  <- dem_cap  <- fact <- toadd <- Year <- gdp_cap <- ssp2dem <- window <- train_add <- NULL
 
-    services <- readSource("EDGE",subtype="ES_buildings")
-    getSets(services) <- gsub("data", "item", getSets(services))
-    data <- services*Unit2Million
-    unit_out = "million square meters times degree [1e6.m2.C]"
-    description_out = "demand pathways for energy service in buildings"
-  }
+      ## start of actual function
+      trp_nodes <- c("ueelTt", "ueLDVt", "ueHDVt")
 
-  if (subtype %in% c("FE", "FE_buildings", "UE_buildings", "FE_for_Eff", "UE_for_Eff", "ES")) {
-    mapping = toolGetMapping(type = "sectoral", name = "structuremappingIO_outputs.csv")
+      ## we work in the REMIND H12 regions to avoid strange ISO country behavior when rescaling
+      mappingfile <- toolGetMapping(type = "regional", name = "regionmappingH12.csv", returnPathOnly = TRUE)
+      rmnd_reg <- toolAggregate(rmnditem, mappingfile, from="CountryCode", to="RegionCode")
 
-    REMIND_dimensions = "REMINDitems_out"
-    sets_names = getSets(data)
+      ## to data.table (we use gdp_SSP2 as a starting point)
+      rmndt <- as.data.table(rmnd_reg)
+      rmndt[, c("scenario", "item") := tstrsplit(scenario.item, ".", fixed = TRUE)][
+        , "scenario.item" := NULL][
+        , year := as.numeric(gsub("y", "", year))]
+      setnames(rmndt, "V3", "region", skip_absent = TRUE)
+      trpdem <- rmndt[item %in% trp_nodes & scenario == "gdp_SSP2"][, scenario := "gdp_SDP"]
 
-    # add total buildings electricity demand: feelb = feelcb + feelhpb + feelrhb
-    mapping <- rbind(
-      mapping,
-      mapping %>%
-        filter(.data$REMINDitems_out %in% c("feelcb", "feelhpb", "feelrhb")) %>%
-        mutate(REMINDitems_out = "feelb")
-    )
+      ## get population
+      pop <- as.data.table(calcOutput("Population"))[
+        , year := as.numeric(gsub("y", "", year))]
+      setnames(pop, c("variable", 'iso3c'), c("scenario", 'region'),
+               skip_absent = TRUE)
 
-  } else if (subtype %in% c("EsUeFe_in","EsUeFe_out")){
+      ## intrapolate missing years
+      yrs <- sort(union(pop$year, trpdem$year))
+      pop <- pop[CJ(region=pop$region, year=yrs, scenario=pop$scenario, unique=T),
+                 on=c("region", "year", "scenario")]
+      pop[, value := approx(x=.SD$year, y=.SD$value, xout=.SD$year)$y,
+          by=c("region", "scenario")]
 
-      mapping_path <- toolGetMapping(type = "sectoral", name = "structuremappingIO_EsUeFe.csv", returnPathOnly = TRUE)
-      mapping = read.csv2(mapping_path, stringsAsFactors = F)
-  }
-  #----- PROCESS DATA ------------------
+      ## merge scenario names
+      pop[, scenario := gsub("pop_", "gdp_", scenario)]
+      setnames(pop, "value", "pop")
 
-  regions  <- getRegions(data)
-  years    <- getYears(data)
-  scenarios <- getScens(data)
+      demPop <- pop[trpdem, on=c("year", "region", "scenario")]
+      demPop[, dem_cap := value/pop * 1e3] # EJ/10^6=TJ (pop. in millions), scale to GJ/cap*yr
 
-  if(subtype %in% c("FE_for_Eff", "UE_for_Eff")){
+      gdp_iso <- calcOutput("GDP", aggregate = F)[,, "gdp_SDP"]
+      gdp_iso <- time_interpolate(gdp_iso, getYears(rmnd_reg))
+      gdp_reg <- toolAggregate(gdp_iso, mappingfile, from="CountryCode", to="RegionCode")
+      getSets(gdp_reg) <- c("region", "Year", "scenario")
+      ## load GDP
+      gdp <- as.data.table(gdp_reg)[
+        , year := as.numeric(gsub("y", "", Year))][
+        , Year := NULL]
 
-    #Select items from EDGE v3, which is based on the distinct UE and FE
-    mapping = mapping[grepl("^.*_fe$",mapping$EDGEitems),]
+      setnames(gdp, "value", "gdp")
 
-    # Replace the FE input with UE inputs, but let the output names as in REMIND
-    if (subtype %in% c("UE_for_Eff")){
-    mapping$EDGEitems = gsub("_fe$","_ue",mapping$EDGEitems)
+      ## merge
+      demPop <- gdp[demPop, on=c("year", "region", "scenario")]
+      demPop[, gdp_cap := gdp/pop]
+
+      ## add new scenario from SSP2
+      newdem <- demPop
+
+      setkey(newdem, "year", "item")
+      newdem[, ssp2dem := dem_cap]
+      for(yr in seq(2025, 2100, 5)){
+        it <- "ueLDVt"
+        target <- 7 ## GJ
+        switch_yrs <- 10
+        drive <- 0.12
+        prv_row <- newdem[year == yr - 5 & item == it]
+        newdem[year == yr & item == it,
+               window := ifelse(prv_row$dem_cap - target >= 0,
+                                drive * pmin((prv_row$dem_cap - target)^2/target^2, 0.2),
+                                -drive * (target - prv_row$dem_cap)/target)]
+
+        newdem[year == yr & item == it,
+               dem_cap := (1-window)^5 * prv_row$dem_cap * pmin((yr - 2020)/switch_yrs, 1) + ssp2dem * (1 - pmin((yr - 2020)/switch_yrs, 1))]
+
+        it <- "ueHDVt"
+        target <- 9
+        prv_row <- newdem[year == yr - 5 & item == it]
+        newdem[year == yr & item == it,
+               window := ifelse(prv_row$dem_cap - target >= 0,
+                                drive * pmin((prv_row$dem_cap - target)^2/target^2, 0.2),
+                                -drive * (target - prv_row$dem_cap)/target)]
+        newdem[year == yr & item == it,
+               dem_cap := (1-window)^5 * prv_row$dem_cap * pmin((yr - 2020)/switch_yrs, 1) + ssp2dem * (1 - pmin((yr - 2020)/switch_yrs, 1))]
+
+      }
+
+      newdem[, c("window", "ssp2dem") := NULL]
+
+      ## toplot <- rbind(demPop, newdem)
+
+      ## ggplot(toplot[item == "ueHDVt" & region %in% c("CHN", "USA", "IND", "JPN") & scenario %in% c("gdp_SDP", "gdp_SSP2")], aes(x=year, y=dem_cap)) +
+      ##   geom_line(aes(color=scenario)) +
+      ##   facet_wrap(~region)
+
+      ## add trains
+      trns <- function(year){
+        if(year <= 2020)
+          return(0)
+        else
+          return((year-2020)^2 * 0.000018) # at 2100, this is ~ 11.5%
+      }
+
+      yrs <- unique(newdem$year)
+      trainsdt <- data.table(year=yrs, fact=sapply(yrs, trns))
+
+      newdem <- newdem[trainsdt, on="year"]
+
+      ## both freight and passenger road are reduced in favour of trains
+      newdem[item %in% c("ueHDVt", "ueLDVt"), toadd := dem_cap * fact]
+      newdem[item %in% c("ueHDVt", "ueLDVt"), dem_cap := dem_cap - toadd]
+
+      newdem[, train_add := 0]
+      newdem[item == "ueelTt" & year > 2025, dem_cap := newdem[item == "ueelTt" & year == 2025]$dem_cap, by=year]
+
+      ## we add it to trains
+      newdem[year > 2020, train_add := sum(toadd, na.rm = T),
+             by=c("year", "region")]
+      ## replace old values
+      newdem[item == "ueelTt", dem_cap := dem_cap + train_add][
+        , c("toadd", "train_add", "fact") := NULL]
+
+      ## ggplot(newdem[region %in% c("SSA", "USA", "IND", "JPN")], aes(x=year, y=dem_cap)) +
+      ##   geom_line(aes(color=item)) +
+      ##   facet_wrap(~region)
+
+      ## multiply by population
+      newdem[, value := dem_cap * pop / 1e3] # back to EJ
+
+      ## constant for t>2100
+      newdem[year > 2100, value := newdem[year == 2100]$value, by="year"]
+
+      ## ggplot(newdem[region %in% c("CHN", "USA", "IND", "JPN"), sum(dem_cap), by=.(year, region)], aes(x=year, y=V1)) +
+      ##   geom_line() +
+      ##   facet_wrap(~region)
+      newdem <- suppressWarnings(as.magpie(newdem[, c("region", "year", "scenario", "item", "value")]))
+      dem_iso <- toolAggregate(newdem, mappingfile, gdp_iso, from="RegionCode", to="CountryCode")
+      getSets(dem_iso)[1] <- "region"
+
+      return(dem_iso)
+
     }
-    # Reduce data set to relevant items
-    data = data[,,unique(mapping$EDGEitems)]
-  }
 
-  #Modify mapping
-  if (subtype == "EsUeFe_in"){
-    mapping = mapping[c("EDGEinput","REMINDitems_in","REMINDitems_out","REMINDitems_tech","weight_input")]
-    REMIND_dimensions = c("REMINDitems_in","REMINDitems_out","REMINDitems_tech")
-    colnames(mapping) = c("EDGEitems",REMIND_dimensions,"weight_Fedemand")
+    addSDP_industry <- function(reminditems) {
+      # Modify industry FE trajectories of SSP1 (and SSP2) to generate SDP
+      # scenario trajectories
 
-    data = data[,,unique(mapping$EDGEitems)]
+      # mask non-global variables so R doesn't get its panties twisted
+      year <- Year <- Data1 <- Data2 <- Region <- Value <- Data3 <- scenario <-
+        iso3c <- value <- variable <- pf <- FE <- VA <- GDP <- VApGDP <- FEpVA <-
+        gdp_SSP1 <- gdp_SSP2 <- f <- gdp_SDP <- .FE <- f.mod <- gdp <- pop <-
+        GDPpC <- item <- NULL
 
-    sets_names = c("region","year","scenario","item","out","tech")
+      # output years
+      years <- as.integer(sub('^y', '', getYears(reminditems)))
 
-  } else if (subtype == "EsUeFe_out"){
-    mapping = mapping[c("EDGEoutput","REMINDitems_in","REMINDitems_out","REMINDitems_tech","weight_output")]
-    REMIND_dimensions = c("REMINDitems_in","REMINDitems_out","REMINDitems_tech")
-    colnames(mapping) = c("EDGEitems",REMIND_dimensions,"weight_Fedemand")
+      tmp_GDPpC <- bind_rows(
+        # load GDP projections
+        tmp_GDP <- calcOutput('GDP', FiveYearSteps = FALSE,
+                              aggregate = FALSE) %>%
+          as.data.frame() %>%
+          as_tibble() %>%
+          character.data.frame() %>%
+          mutate(Year = as.integer(as.character(Year))) %>%
+          filter(grepl('^gdp_SSP[12]$', Data1),
+                 Year %in% years) %>%
+          separate(col = 'Data1', into = c('variable', 'scenario'), sep = '_') %>%
+          select('scenario', iso3c = 'Region', year = 'Year', 'variable',
+                 value = 'Value'),
 
-    data = data[,,unique(mapping$EDGEitems)]
+        tmp_pop <- calcOutput('Population', FiveYearSteps = FALSE,
+                              aggregate = FALSE) %>%
+          as.data.frame() %>%
+          as_tibble()  %>%
+          character.data.frame() %>%
+          mutate(Year = as.integer(as.character(Year))) %>%
+          filter(grepl('^pop_SSP[12]$', Data1),
+                 Year %in% years) %>%
+          separate(col = 'Data1', into = c('variable', 'scenario'), sep = '_') %>%
+          select('scenario', iso3c = 'Region', year = 'Year', 'variable',
+                 value = 'Value')
+      ) %>%
+        mutate(scenario = paste0('gdp_', scenario)) %>%
+        pivot_wider(names_from = 'variable') %>%
+        group_by(.data$scenario, .data$iso3c, .data$year) %>%
+        summarise(GDPpC = .data$gdp / .data$pop, .groups = 'drop')
 
-    sets_names = c("region","year","scenario","in","item","tech")
-  }
+      # - for each country and scenario, compute a GDPpC-dependent specific energy
+      #   use reduction factor according to 3e-7 * GDPpC + 0.2 [%], which is
+      #   capped at 0.7 %
+      #   - the mean GDPpC of countries with GDPpC > 15000 (in 2015) is about 33k
+      #   - so efficiency gains range from 0.4 % at zero GDPpC (more development
+      #     leeway) to 1.4 % at 33k GDPpC (more stringent energy efficiency)
+      #   - percentage numbers are halved and applied twice, to VA/GDP and FE/VA
+      # - linearly reduce this reduction factor from 1 to 0 over the 2020-2150
+      #   interval
+      # - cumulate the reduction factor over the time horizon
 
-  edge_names = getNames(data, dim = "item")
+      SSA_countries <- read_delim(
+        file = toolGetMapping(type = 'regional', name = 'regionmappingH12.csv', returnPathOnly = TRUE),
+        delim = ';',
+        col_names = c('country', 'iso3c', 'region'),
+        col_types = 'ccc',
+        skip = 1) %>%
+        filter('SSA' == !!sym('region')) %>%
+        select(-'country', -'region') %>%
+        getElement('iso3c')
+
+      sgma <- 8e3
+      cutoff <- 1.018
+      epsilon <- 0.018
+      exp1 <- 3
+      exp2 <- 1.5
+
+      reduction_factor <- tmp_GDPpC %>%
+        interpolate_missing_periods(year = seq_range(range(year)),
+                                    value = 'GDPpC') %>%
+        group_by(scenario, iso3c) %>%
+        mutate(
+          # no reduction for SSA countries before 2050, to allow for more
+          # equitable industry and infrastructure development
+          f = cumprod(ifelse(2020 > year, 1, pmin(cutoff, 1 + 4*epsilon*((sgma/GDPpC)^exp1 - (sgma/GDPpC)^exp2))
+                             ))) %>%
+        ungroup() %>%
+        select(-GDPpC) %>%
+        filter(year %in% years)
+
+      bind_rows(
+        # select industry FE use
+        reminditems %>%
+          as.data.frame() %>%
+          as_tibble() %>%
+          mutate(Year = as.integer(as.character(Year))) %>%
+          filter(grepl('^gdp_SSP[12]$', Data1),
+                 grepl('fe..i', Data2)) %>%
+          select(scenario = Data1, iso3c = Region, year = Year, variable = Data2,
+                 value = Value) %>%
+          character.data.frame(),
+
+        # reuse GDP projections
+        tmp_GDP %>%
+          mutate(variable = 'GDP',
+                 scenario = paste0('gdp_', scenario)),
+
+        # load VA projections
+        readSource('EDGE_Industry', 'projections_VA_iso3c', convert = FALSE) %>%
+          as.data.frame() %>%
+          as_tibble() %>%
+          select(scenario = Data1, iso3c = Region, year = Year, sector = Data2,
+                 value = Value) %>%
+          filter(grepl('^gdp_SSP[12]$', scenario),
+                 'Total' != iso3c,
+                 as.character(year) %in% years) %>%
+          mutate(iso3c = as.character(iso3c),
+                 year = as.integer(as.character(year))) %>%
+          group_by(scenario, iso3c, year) %>%
+          summarise(value = sum(value), .groups = 'drop') %>%
+          mutate(variable = 'VA') %>%
+          interpolate_missing_periods(year = years, expand.values = TRUE) %>%
+          character.data.frame()
+      ) %>%
+        spread(variable, value) %>%
+        gather(pf, FE, matches('^fe..i$')) %>%
+        inner_join(reduction_factor, c('scenario', 'iso3c', 'year')) %>%
+        mutate(VApGDP = VA  / GDP,
+               FEpVA  = FE  / VA) %>%
+        # Modify reduction factor f based on feeli share in pf
+        # f for feeli is sqrt of f; for for others choosen such that total
+        # reduction equals f
+        group_by(scenario, iso3c, year) %>%
+        mutate(f.mod = ifelse('feeli' == pf & f < 1, sqrt(f), f)) %>%
+        ungroup() %>%
+        select(-f, f = f.mod) %>%
+        # gather(variable, value, GDP, FE, VA, VApGDP, FEpVA) %>%
+        # SDP scenario is equal to SSP1 scenario, except for VA/GDP and FE/VA
+        # indicators, which are equal to the lower value of the SSP1 or SSP2
+        # scenario times the reduction factor f(t)
+        group_by(iso3c, year, pf) %>%
+        mutate(VApGDP = min(VApGDP) * f,
+               FEpVA  = min(FEpVA)  * f) %>%
+        ungroup() %>%
+        select(-f) %>%
+        filter('gdp_SSP2' != scenario) %>%
+        mutate(scenario = 'gdp_SDP') %>%
+        mutate(.FE = FEpVA * VApGDP * GDP,
+               value = ifelse(!is.na(.FE), .FE, FE)) %>%
+        select(scenario, iso3c, year, item = pf, value) %>%
+        # TODO: differentiate these scenarios if there is a applicable storyline
+        # for them
+        complete(nesting(iso3c, year, item, value),
+                 scenario = paste0('gdp_SDP', c('', '_EI', '_MC', '_RC'))) %>%
+        select(scenario, iso3c, year, item, value) %>%
+        as.magpie() %>%
+        return()
+    }
+
+    #----- READ-IN DATA ------------------
+    if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings",
+                       "UE_buildings", "FE_for_Eff", "UE_for_Eff")) {
+
+      stationary <- readSource("EDGE",subtype="FE_stationary")
+      buildings  <- readSource("EDGE",subtype="FE_buildings")
+
+      # consider only fixed climate
+      if (subtype %in% c("FE_buildings", "UE_buildings")) {
+        rcps <- paste0("rcp", gsub("p", "", getItems(buildings, "rcp")))
+        rcps <- gsub("rcpfixed", "none", rcps)
+        getItems(buildings, "rcp") <- rcps
+        stationary <- addDim(stationary, rcps, "rcp")
+      } else {
+        rcps <- NULL
+        buildings <- mselect(buildings, rcp = "fixed", collapseNames = TRUE)
+      }
+
+      ## fix issue with trains in transport trajectories: they seem to be 0 for t>2100
+      if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings", "UE_buildings") &
+          all(mselect(stationary, year = "y2105", scenario = "SSP2", item = "feelt") == 0)) {
+        stationary[, seq(2105, 2150, 5), "feelt"] = time_interpolate(stationary[, 2100, "feelt"], seq(2105, 2150, 5))
+      }
+
+      ## common years
+
+      ## stationary year range is in line with requirements on the RMND side
+      fill_years <- setdiff(getYears(stationary),getYears(buildings))
+      buildings <- time_interpolate(buildings,interpolated_year = fill_years, integrate_interpolated_years = T, extrapolation_type = "constant")
+
+      y <- if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings", "UE_Buildings")) {
+        getYears(stationary)  # >= 1993
+      } else {
+        intersect(getYears(stationary), getYears(buildings))  # >= 2000
+      }
+
+      data <- mbind(stationary[, y, ], buildings[, y, ])
+
+      unit_out = "EJ"
+      description_out <- ifelse(subtype %in% c("FE_for_Eff", "UE_for_Eff"),
+        "demand pathways for useful/final energy in buildings and industry corresponding to the final energy items in REMIND",
+        "demand pathways for final energy in buildings and industry in the original file")
+    }
+
+    if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out")) {
+      # ---- _ modify Industry FE data to carry on current trends ----
+      v <- grep('\\.fe(..i$|ind)', getNames(data), value = TRUE)
+
+      dataInd <- data[,,v] %>%
+        as.quitte() %>%
+        as_tibble() %>%
+        select('scenario', 'iso3c' = 'region', 'pf' = 'item', 'year' = 'period',
+               'value') %>%
+        character.data.frame()
+
+      regionmapping <- toolGetMapping(type = 'regional',
+                                      name = 'regionmappingH12.csv') %>%
+        select(country = 'X', iso3c = 'CountryCode', region = 'RegionCode')
+
+      historic_trend <- c(2004, 2015)
+      phasein_period <- c(2015, 2050)
+      phasein_time   <- phasein_period[2] - phasein_period[1]
+
+      dataInd <- bind_rows(
+        dataInd %>%
+          filter(phasein_period[1] > !!sym('year')),
+        inner_join(
+          # calculate regional trend
+          dataInd %>%
+            # get trend period
+            filter(between(!!sym('year'), historic_trend[1], historic_trend[2]),
+                   0 != !!sym('value')) %>%
+            # sum regional totals
+            full_join(regionmapping %>% select(-!!sym('country')), 'iso3c') %>%
+            group_by(!!sym('scenario'), !!sym('region'), !!sym('pf'),
+                     !!sym('year')) %>%
+              summarise(value = sum(!!sym('value')), .groups = 'drop') %>%
+            # calculate average trend over trend period
+            interpolate_missing_periods(year = seq_range(historic_trend),
+                                        expand.values = TRUE) %>%
+            group_by(!!sym('scenario'), !!sym('region'), !!sym('pf')) %>%
+            summarise(trend = mean(!!sym('value') / lag(!!sym('value')),
+                                     na.rm = TRUE),
+                        .groups = 'drop') %>%
+            # only use negative trends (decreasing energy use)
+            mutate(trend = ifelse(!!sym('trend') < 1, !!sym('trend'), NA)),
+          # modify data projection
+          dataInd %>%
+            filter(phasein_period[1] <= !!sym('year')) %>%
+            interpolate_missing_periods(
+              year = phasein_period[1]:max(dataInd$year)) %>%
+            group_by(!!sym('scenario'), !!sym('iso3c'), !!sym('pf')) %>%
+            mutate(
+              growth = replace_na(!!sym('value') / lag(!!sym('value')), 1)) %>%
+            full_join(regionmapping %>% select(-'country'), 'iso3c'),
+          c('scenario', 'region', 'pf')) %>%
+        group_by(!!sym('scenario'), !!sym('iso3c'), !!sym('pf')) %>%
+        mutate(
+          # replace NA (positive) trends with end. growth rates -> no change
+          trend = ifelse(is.na(!!sym('trend')), !!sym('growth'),
+                         !!sym('trend')),
+          value_ = first(!!sym('value'))
+            * cumprod(
+              ifelse(
+                phasein_period[1] == !!sym('year'), 1,
+                ( !!sym('trend')
+                * pmax(0, phasein_period[2] - !!sym('year') + 1)
+                + !!sym('growth')
+                * pmin(phasein_time, !!sym('year') - phasein_period[1] - 1)
+                ) / phasein_time)),
+          value = ifelse(is.na(!!sym('value_')) | 0 == !!sym('value_'),
+                         !!sym('value'), !!sym('value_'))) %>%
+        ungroup() %>%
+        select(-'region', -'value_', -'trend', -'growth') %>%
+        filter(!!sym('year') %in% unique(dataInd$year))
+      ) %>%
+        rename('region' = 'iso3c', 'item' = 'pf') %>%
+        as.magpie()
+
+      data <- mbind(data[,,v, invert = TRUE], dataInd)
+
+      # ---- _ modify SSP1 Industry FE demand ----
+      # compute a reduction factor of 1 before 2021, 0.84 in 2050, and increasing
+      # to 0.78 in 2150
+      f <- as.integer(sub('^y', '', y)) - 2020
+      f[f < 0] <- 0
+      f <- 0.95 ^ pmax(0, log(f))
+
+      # get Industry FE items
+      v <- grep('^SSP1\\.fe(..i$|ind)', getNames(data), value = TRUE)
+
+      # apply changes
+      for (i in 1:length(y)) {
+        if (1 != f[i]) {
+          data[,y[i],v] <- data[,y[i],v] * f[i]
+        }
+      }
+
+    } else if (subtype == "ES"){
+      Unit2Million = 1e-6
+
+      services <- readSource("EDGE",subtype="ES_buildings")
+      getSets(services) <- gsub("data", "item", getSets(services))
+      data <- services*Unit2Million
+      unit_out = "million square meters times degree [1e6.m2.C]"
+      description_out = "demand pathways for energy service in buildings"
+    }
+
+    if (subtype %in% c("FE", "FE_buildings", "UE_buildings", "FE_for_Eff", "UE_for_Eff", "ES")) {
+      mapping = toolGetMapping(type = "sectoral", name = "structuremappingIO_outputs.csv")
+
+      REMIND_dimensions = "REMINDitems_out"
+      sets_names = getSets(data)
+
+      # add total buildings electricity demand: feelb = feelcb + feelhpb + feelrhb
+      mapping <- rbind(
+        mapping,
+        mapping %>%
+          filter(.data$REMINDitems_out %in% c("feelcb", "feelhpb", "feelrhb")) %>%
+          mutate(REMINDitems_out = "feelb")
+      )
+
+    } else if (subtype %in% c("EsUeFe_in","EsUeFe_out")){
+
+        mapping_path <- toolGetMapping(type = "sectoral", name = "structuremappingIO_EsUeFe.csv", returnPathOnly = TRUE)
+        mapping = read.csv2(mapping_path, stringsAsFactors = F)
+    }
+    #----- PROCESS DATA ------------------
+
+    regions  <- getRegions(data)
+    years    <- getYears(data)
+    scenarios <- getScens(data)
+
+    if(subtype %in% c("FE_for_Eff", "UE_for_Eff")){
+
+      #Select items from EDGE v3, which is based on the distinct UE and FE
+      mapping = mapping[grepl("^.*_fe$",mapping$EDGEitems),]
+
+      # Replace the FE input with UE inputs, but let the output names as in REMIND
+      if (subtype %in% c("UE_for_Eff")){
+      mapping$EDGEitems = gsub("_fe$","_ue",mapping$EDGEitems)
+      }
+      # Reduce data set to relevant items
+      data = data[,,unique(mapping$EDGEitems)]
+    }
+
+    #Modify mapping
+    if (subtype == "EsUeFe_in"){
+      mapping = mapping[c("EDGEinput","REMINDitems_in","REMINDitems_out","REMINDitems_tech","weight_input")]
+      REMIND_dimensions = c("REMINDitems_in","REMINDitems_out","REMINDitems_tech")
+      colnames(mapping) = c("EDGEitems",REMIND_dimensions,"weight_Fedemand")
+
+      data = data[,,unique(mapping$EDGEitems)]
+
+      sets_names = c("region","year","scenario","item","out","tech")
+
+    } else if (subtype == "EsUeFe_out"){
+      mapping = mapping[c("EDGEoutput","REMINDitems_in","REMINDitems_out","REMINDitems_tech","weight_output")]
+      REMIND_dimensions = c("REMINDitems_in","REMINDitems_out","REMINDitems_tech")
+      colnames(mapping) = c("EDGEitems",REMIND_dimensions,"weight_Fedemand")
+
+      data = data[,,unique(mapping$EDGEitems)]
+
+      sets_names = c("region","year","scenario","in","item","tech")
+    }
+
+    edge_names = getNames(data, dim = "item")
 
 
 
-  mapping = na.omit(mapping[c("EDGEitems",REMIND_dimensions,"weight_Fedemand")])
-  mapping = mapping[which(mapping$EDGEitems %in% edge_names),]
-  mapping = unique(mapping)
+    mapping = na.omit(mapping[c("EDGEitems",REMIND_dimensions,"weight_Fedemand")])
+    mapping = mapping[which(mapping$EDGEitems %in% edge_names),]
+    mapping = unique(mapping)
 
 
-  magpnames = mapping[REMIND_dimensions]
-  magpnames <- unique(magpnames)
-  if (subtype %in% c("FE_buildings", "UE_buildings")) {
-    # filter only buildings (simple) ppf
-    magpnames <- filter(magpnames, grepl("^fe..b$|^feel..b$|^feelcb$", .data$REMINDitems_out))
-  }
-  if (subtype == "UE_buildings") {
-    # change mapping from FE to UE
-    mapping <- mapping %>%
-      mutate(EDGEitems = gsub("_fe$", "_ue", .data[["EDGEitems"]]),
-             REMINDitems_out = gsub("^fe", "ue", .data[["REMINDitems_out"]])) %>%
-      rbind(mapping)
-    magpnames <- magpnames %>%
-      mutate(REMINDitems_out = gsub("^fe", "ue", .data[["REMINDitems_out"]]))
-  }
-  magpnames <- expand_vectors(
+    magpnames = mapping[REMIND_dimensions]
+    magpnames <- unique(magpnames)
     if (subtype %in% c("FE_buildings", "UE_buildings")) {
-      cartesian(scenarios, rcps)
-    } else {
-      scenarios
-    },
-    magpnames)
-
-  if (length(setdiff(edge_names, mapping$EDGEitems) > 0 )) stop("Not all EDGE items are in the mapping")
-
-
-  # make an empty new magpie object
-  reminditems <- as.magpie(array(dim = c(length(regions), length(years), length(magpnames)),
-                                 dimnames = list(regions, years, magpnames)))
-  getSets(reminditems) <- sets_names
-
-  datatmp <- data
-  # Take the names of reminditems without scenario and rcp dimension
-  names_NoScen <- lapply(getNames(reminditems), function(name) {
-    strsplit(name, ".", fixed = TRUE)[[1]] %>%
-      `[`(!tail(getSets(reminditems), -2) %in% c("scenario", "rcp")) %>%
-      paste(collapse = ".")
-  })
-
-  for (reminditem in names_NoScen) {
-    # Concatenate names from mapping columns so that they are comparable with
-    # names from magclass object
-    if (length(REMIND_dimensions) > 1) {
-      names_mapping <- apply(mapping[REMIND_dimensions], 1, paste, collapse = ".")
-    } else {
-      names_mapping <- mapping[[REMIND_dimensions]]
+      # filter only buildings (simple) ppf
+      magpnames <- filter(magpnames, grepl("^fe..b$|^feel..b$|^feelcb$", .data$REMINDitems_out))
     }
-    # Only select EDGE variables which correspond to the remind
-    testdf <- mapping[names_mapping == reminditem,
-                      c("EDGEitems", "weight_Fedemand")]
-    prfl <- testdf[,"EDGEitems"]
-    vec <- as.numeric(mapping[rownames(testdf),"weight_Fedemand"])
-    names(vec) <- prfl
-    mselect(datatmp, item = prfl) <- mselect(data, item = prfl) * as.magpie(vec)
-    reminditems[, , reminditem] <- dimSums(mselect(datatmp, item = prfl),
-                                           dim = "item", na.rm = TRUE)
-  }
+    if (subtype == "UE_buildings") {
+      # change mapping from FE to UE
+      mapping <- mapping %>%
+        mutate(EDGEitems = gsub("_fe$", "_ue", .data[["EDGEitems"]]),
+               REMINDitems_out = gsub("^fe", "ue", .data[["REMINDitems_out"]])) %>%
+        rbind(mapping)
+      magpnames <- magpnames %>%
+        mutate(REMINDitems_out = gsub("^fe", "ue", .data[["REMINDitems_out"]]))
+    }
+    magpnames <- expand_vectors(
+      if (subtype %in% c("FE_buildings", "UE_buildings")) {
+        cartesian(scenarios, rcps)
+      } else {
+        scenarios
+      },
+      magpnames)
 
-  #Change the scenario names for consistency with REMIND sets
-  getNames(reminditems) <- gsub("^SSP","gdp_SSP",getNames(reminditems))
-  getNames(reminditems) <- gsub("SDP","gdp_SDP",getNames(reminditems))
-
-  if ('FE' == subtype) {
-
-    # ---- _modify SSP1/SSP2 data of CHN/IND further ----
-    # To achieve projections more in line with local experts, apply tuning
-    # factor f to liquids and gas consumption in industry in CHN and IND.
-    # Apply additional energy intensity reductions 2015-30, that are phased out
-    # halfway until 2040 again.
-    # IEIR - initial energy intensity reduction [% p.a.] in 2016
-    # FEIR - final energy intensity recovery [% p.a.] in 2040
-    # The energy intensity reduction is cumulative over the 2016-40 interval
-    # and thereafter constant.
-
-    mod_factors <- tribble(
-      # enter tuning factors for regions/energy carriers
-      ~region,   ~pf,        ~IEIR,   ~FEIR,
-      'CHN',     'fehoi',     2.5,    -0.5,
-      'CHN',     'fegai',    -2.5,     3,
-      'CHN',     'feeli',     0.5,     1.5,
-      'IND',     'fehoi',     3,       0,
-      'IND',     'fegai',    12,      -5) %>%
-      # SSP1 factors are half those of SSP2
-      gather('variable', 'gdp_SSP2', !!sym('IEIR'), !!sym('FEIR'),
-             factor_key = TRUE) %>%
-      mutate(gdp_SSP1 = !!sym('gdp_SSP2') / 2) %>%
-      gather('scenario', 'value', matches('^gdp_SSP')) %>%
-      spread('variable', 'value') %>%
-      mutate(t = as.integer(2016)) %>%
-      # add missing combinations (neutral multiplication by 1) for easy joining
-      complete(crossing(!!sym('scenario'), !!sym('region'), !!sym('pf'),
-                        !!sym('t')),
-               fill = list(IEIR = 0, FEIR = 0)) %>%
-      # fill 2016-40 values
-      complete(nesting(!!sym('scenario'), !!sym('region'), !!sym('pf'),
-                       !!sym('IEIR'), !!sym('FEIR')),
-               t = 2016:2040) %>%
-      group_by(!!sym('scenario'), !!sym('region'), !!sym('pf')) %>%
-      mutate(
-        f = seq(1 - unique(!!sym('IEIR')) / 100,
-                1 - unique(!!sym('FEIR')) / 100,
-                along.with = !!sym('t'))) %>%
-      # extend beyond 2050 (neutral multiplication by 1)
-      complete(t = c(1993:2015, 2041:2150), fill = list(f = 1)) %>%
-      arrange(!!sym('t')) %>%
-      mutate(f = cumprod(!!sym('f'))) %>%
-      filter(t %in% as.integer(sub('y', '', y))) %>%
-      ungroup() %>%
-      select(-'IEIR', -'FEIR')
-
-    mod_factors <- bind_rows(
-      mod_factors,
-
-      mod_factors %>%
-        filter('gdp_SSP2' == .data$scenario) %>%
-        mutate(scenario = 'gdp_SSP2EU')
-    )
-
-    mod_r <- unique(mod_factors$region)
-    mod_sp <- cartesian(unique(mod_factors$scenario),
-                        unique(mod_factors$pf))
-
-    reminditems[mod_r,,mod_sp] <- reminditems[mod_r,,mod_sp] %>%
-      as.quitte() %>%
-      as_tibble() %>%
-      mutate(scenario = as.character(!!sym('scenario')),
-             region   = as.character(!!sym('region')),
-             item     = as.character(!!sym('item'))) %>%
-      full_join(mod_factors, c('scenario', 'region', 'period' = 't',
-                               'item' = 'pf')) %>%
-      mutate(value = !!sym('f') * !!sym('value')) %>%
-      select(-'f') %>%
-      as.quitte() %>%
-      as.magpie()
-
-    # add SDP transport and industry scenarios
-    SDP_industry_transport <- mbind(addSDP_transport(reminditems),
-                                    addSDP_industry(reminditems))
-
-    # delete punk SDP data calculated illicitly in readEDGE('FE_stationary')
-    reminditems <- mbind(
-      reminditems[,,setdiff(getNames(reminditems),
-                            getNames(SDP_industry_transport))],
-      SDP_industry_transport)
-
-    ## calculate *real* useful (i.e., motive) energy instead of
-    ## fossil-fuel equivalents for light- and heavy-duty vehicles
-    ## sources for TtW efficiencies:
-    ##  Cox, B., et al. (2020) Life cycle environmental and cost comparison of current and future passenger cars under different energy scenarios. Applied Energy2.
-    ## Sacchi, R., et al. (2020) carculator: an open-source tool for prospective environmental and economic life cycle assessment of vehicles. When, Where and How can battery-electric vehicles help reduce greenhouse gas emissions? Renewable and Sustainable Energy Reviews, submitted (in review). https://www.psi.ch/en/media/57994/download
-
-    #reminditems[,, "ueLDVt"] <- reminditems[,, "ueLDVt"] * 0.22
-    #reminditems[,, "ueHDVt"] <- reminditems[,, "ueHDVt"] * 0.24
+    if (length(setdiff(edge_names, mapping$EDGEitems) > 0 )) stop("Not all EDGE items are in the mapping")
 
 
-    # ---- Industry subsectors data and FE stubs ----
+    # make an empty new magpie object
+    reminditems <- as.magpie(array(dim = c(length(regions), length(years), length(magpnames)),
+                                   dimnames = list(regions, years, magpnames)))
+    getSets(reminditems) <- sets_names
+
+    datatmp <- data
+    # Take the names of reminditems without scenario and rcp dimension
+    names_NoScen <- lapply(getNames(reminditems), function(name) {
+      strsplit(name, ".", fixed = TRUE)[[1]] %>%
+        `[`(!tail(getSets(reminditems), -2) %in% c("scenario", "rcp")) %>%
+        paste(collapse = ".")
+    })
+
+    for (reminditem in names_NoScen) {
+      # Concatenate names from mapping columns so that they are comparable with
+      # names from magclass object
+      if (length(REMIND_dimensions) > 1) {
+        names_mapping <- apply(mapping[REMIND_dimensions], 1, paste, collapse = ".")
+      } else {
+        names_mapping <- mapping[[REMIND_dimensions]]
+      }
+      # Only select EDGE variables which correspond to the remind
+      testdf <- mapping[names_mapping == reminditem,
+                        c("EDGEitems", "weight_Fedemand")]
+      prfl <- testdf[,"EDGEitems"]
+      vec <- as.numeric(mapping[rownames(testdf),"weight_Fedemand"])
+      names(vec) <- prfl
+      mselect(datatmp, item = prfl) <- mselect(data, item = prfl) * as.magpie(vec)
+      reminditems[, , reminditem] <- dimSums(mselect(datatmp, item = prfl),
+                                             dim = "item", na.rm = TRUE)
+    }
+
+    #Change the scenario names for consistency with REMIND sets
+    getNames(reminditems) <- gsub("^SSP","gdp_SSP",getNames(reminditems))
+    getNames(reminditems) <- gsub("SDP","gdp_SDP",getNames(reminditems))
+
+    if ('FE' == subtype) {
+
+      # ---- _modify SSP1/SSP2 data of CHN/IND further ----
+      # To achieve projections more in line with local experts, apply tuning
+      # factor f to liquids and gas consumption in industry in CHN and IND.
+      # Apply additional energy intensity reductions 2015-30, that are phased out
+      # halfway until 2040 again.
+      # IEIR - initial energy intensity reduction [% p.a.] in 2016
+      # FEIR - final energy intensity recovery [% p.a.] in 2040
+      # The energy intensity reduction is cumulative over the 2016-40 interval
+      # and thereafter constant.
+
+      mod_factors <- tribble(
+        # enter tuning factors for regions/energy carriers
+        ~region,   ~pf,        ~IEIR,   ~FEIR,
+        'CHN',     'fehoi',     2.5,    -0.5,
+        'CHN',     'fegai',    -2.5,     3,
+        'CHN',     'feeli',     0.5,     1.5,
+        'IND',     'fehoi',     3,       0,
+        'IND',     'fegai',    12,      -5) %>%
+        # SSP1 factors are half those of SSP2
+        gather('variable', 'gdp_SSP2', !!sym('IEIR'), !!sym('FEIR'),
+               factor_key = TRUE) %>%
+        mutate(gdp_SSP1 = !!sym('gdp_SSP2') / 2) %>%
+        gather('scenario', 'value', matches('^gdp_SSP')) %>%
+        spread('variable', 'value') %>%
+        mutate(t = as.integer(2016)) %>%
+        # add missing combinations (neutral multiplication by 1) for easy joining
+        complete(crossing(!!sym('scenario'), !!sym('region'), !!sym('pf'),
+                          !!sym('t')),
+                 fill = list(IEIR = 0, FEIR = 0)) %>%
+        # fill 2016-40 values
+        complete(nesting(!!sym('scenario'), !!sym('region'), !!sym('pf'),
+                         !!sym('IEIR'), !!sym('FEIR')),
+                 t = 2016:2040) %>%
+        group_by(!!sym('scenario'), !!sym('region'), !!sym('pf')) %>%
+        mutate(
+          f = seq(1 - unique(!!sym('IEIR')) / 100,
+                  1 - unique(!!sym('FEIR')) / 100,
+                  along.with = !!sym('t'))) %>%
+        # extend beyond 2050 (neutral multiplication by 1)
+        complete(t = c(1993:2015, 2041:2150), fill = list(f = 1)) %>%
+        arrange(!!sym('t')) %>%
+        mutate(f = cumprod(!!sym('f'))) %>%
+        filter(t %in% as.integer(sub('y', '', y))) %>%
+        ungroup() %>%
+        select(-'IEIR', -'FEIR')
+
+      mod_factors <- bind_rows(
+        mod_factors,
+
+        mod_factors %>%
+          filter('gdp_SSP2' == .data$scenario) %>%
+          mutate(scenario = 'gdp_SSP2EU')
+      )
+
+      mod_r <- unique(mod_factors$region)
+      mod_sp <- cartesian(unique(mod_factors$scenario),
+                          unique(mod_factors$pf))
+
+      reminditems[mod_r,,mod_sp] <- reminditems[mod_r,,mod_sp] %>%
+        as.quitte() %>%
+        as_tibble() %>%
+        mutate(scenario = as.character(!!sym('scenario')),
+               region   = as.character(!!sym('region')),
+               item     = as.character(!!sym('item'))) %>%
+        full_join(mod_factors, c('scenario', 'region', 'period' = 't',
+                                 'item' = 'pf')) %>%
+        mutate(value = !!sym('f') * !!sym('value')) %>%
+        select(-'f') %>%
+        as.quitte() %>%
+        as.magpie()
+
+      # add SDP transport and industry scenarios
+      SDP_industry_transport <- mbind(addSDP_transport(reminditems),
+                                      addSDP_industry(reminditems))
+
+      # delete punk SDP data calculated illicitly in readEDGE('FE_stationary')
+      reminditems <- mbind(
+        reminditems[,,setdiff(getNames(reminditems),
+                              getNames(SDP_industry_transport))],
+        SDP_industry_transport)
+
+      ## calculate *real* useful (i.e., motive) energy instead of
+      ## fossil-fuel equivalents for light- and heavy-duty vehicles
+      ## sources for TtW efficiencies:
+      ##  Cox, B., et al. (2020) Life cycle environmental and cost comparison of current and future passenger cars under different energy scenarios. Applied Energy2.
+      ## Sacchi, R., et al. (2020) carculator: an open-source tool for prospective environmental and economic life cycle assessment of vehicles. When, Where and How can battery-electric vehicles help reduce greenhouse gas emissions? Renewable and Sustainable Energy Reviews, submitted (in review). https://www.psi.ch/en/media/57994/download
+
+      #reminditems[,, "ueLDVt"] <- reminditems[,, "ueLDVt"] * 0.22
+      #reminditems[,, "ueHDVt"] <- reminditems[,, "ueHDVt"] * 0.24
+
+
+      # ---- Industry subsectors data and FE stubs ----
     ## subsector activity projections ----
     industry_subsectors_ue <- mbind(
       calcOutput(
@@ -922,34 +922,64 @@ calcFEdemand <- function(subtype = "FE") {
       # these scenarios are pegged to SSP2EU
       industry_subsectors_material_alpha %>%
         full_join(
-          foo %>%
-            filter('gdp_SSP2EU' == .data$scenario) %>%
-            group_by(!!!syms(c('subsector', 'iso3c', 'year'))) %>%
-            summarise(specific.production = .data$value / .data$GDP,
-                      .groups = 'drop') %>%
-            interpolate_missing_periods_(
-              periods = list(year = seq_range(range(.$year))),
-              value = 'specific.production',
-              method = 'linear') %>%
+          full_join(
+            foo %>%
+              filter('gdp_SSP2EU' == .data$scenario) %>%
+              # keep specific production constant for historic years without
+              # production
+              group_by(!!!syms(c('iso3c', 'subsector'))) %>%
+              mutate(specific.production = .data$value / .data$GDP,
+                     specific.production = ifelse(
+                       0 != .data$value, .data$specific.production,
+                       first(.data$specific.production[0 != .data$value],
+                             order_by = .data$year))) %>%
+              ungroup() %>%
+              select('iso3c', 'year', 'subsector', 'specific.production') %>%
+              interpolate_missing_periods_(
+                periods = list(year = seq_range(range(.$year))),
+                value = 'specific.production',
+                method = 'linear'),
+
+            # mark years which have no historic production so that we can set
+            # them to 0 once we calculated future production for the new
+            # scenarios
+            foo %>%
+              filter('gdp_SSP2EU' == .data$scenario) %>%
+              mutate(fake.value = 0 == .data$value) %>%
+              select('iso3c', 'year', 'subsector', 'fake.value') %>%
+              interpolate_missing_periods_(
+                periods = list(year = seq_range(range(.$year))),
+                value = 'fake.value',
+                method = 'linear') %>%
+              mutate(fake.value = 0 != .data$fake.value),
+
+            c('iso3c', 'year', 'subsector')
+          ) %>%
             full_join(region_mapping_21, 'iso3c'),
 
           c('region', 'subsector')
         ) %>%
         group_by(!!!syms(c('scenario', 'subsector', 'iso3c'))) %>%
         mutate(
+          # alpha factors converge linearly towards zero over the convergence
+          # time
+          conv.fctr = 1 - pmin(1, ( (.data$year - 2015)
+                                    / .data$convergence_time)),
+          alpha.conv = ifelse(2015 >= .data$year, 1,
+                              1 - .data$alpha * .data$conv.fctr),
+          # specific production is scaled with the cumulated converged alpha
+          # factors
+          cum.fctr = cumprod(.data$alpha.conv),
           specific.production = ifelse(
-            2015 >= .data$year, .data$specific.production,
-            ( .data$specific.production[2015 == .data$year]
-            * cumprod(
-                ifelse(
-                  2015 >= .data$year, 1,
-                  1 - .data$alpha * (1 - pmin(1, (.data$year - 2015) / 50))
-                )
-              )
-            )
-          )
-        ) %>%
+              2015 >= .data$year, .data$specific.production,
+              ( .data$specific.production[2015 == .data$year]
+              * .data$cum.fctr
+              ))
+              # ensure that years without historic production are 0
+            * (1 - .data$fake.value)) %>%
         ungroup() %>%
+        select('region', 'iso3c', 'year', 'scenario', 'subsector',
+               'specific.production') %>%
         filter(.data$year %in% unique(foo$year)) %>%
         left_join(
           bind_rows(

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -1609,36 +1609,38 @@ calcFEdemand <- function(subtype = "FE") {
              .data$specific.energy < .data$limit) %>%
       select('scenario', 'region', 'subsector', 'year')
 
-    industry_subsectors_specific_energy <- bind_rows(
-      industry_subsectors_specific_energy %>%
-        anti_join(
-          too_low_projections,
+    if (0 != nrow(too_low_projections)) {
+      industry_subsectors_specific_energy <- bind_rows(
+        industry_subsectors_specific_energy %>%
+          anti_join(
+            too_low_projections,
 
-          c('scenario', 'region', 'subsector', 'year')
-        ),
+            c('scenario', 'region', 'subsector', 'year')
+          ),
 
-      industry_subsectors_specific_energy %>%
-        semi_join(
-          too_low_projections %>%
-            select(-'region'),
+        industry_subsectors_specific_energy %>%
+          semi_join(
+            too_low_projections %>%
+              select(-'region'),
 
-          c('scenario', 'subsector', 'year')
-        ) %>%
-        anti_join(
-          too_low_projections,
+            c('scenario', 'subsector', 'year')
+          ) %>%
+          anti_join(
+            too_low_projections,
 
-          c('scenario', 'region', 'subsector', 'year')
-        ) %>%
-        group_by(!!!syms(c('scenario', 'subsector', 'year'))) %>%
-        summarise(specific.energy = mean(.data$specific.energy),
-                  .groups = 'drop') %>%
-        full_join(
-          too_low_projections,
+            c('scenario', 'region', 'subsector', 'year')
+          ) %>%
+          group_by(!!!syms(c('scenario', 'subsector', 'year'))) %>%
+          summarise(specific.energy = mean(.data$specific.energy),
+                    .groups = 'drop') %>%
+          full_join(
+            too_low_projections,
 
-          c('scenario', 'subsector', 'year')
-        ) %>%
-        assert(not_na, everything())
-    )
+            c('scenario', 'subsector', 'year')
+          ) %>%
+          assert(not_na, everything())
+      )
+    }
 
     # decrease values by alpha p.a.
     industry_subsectors_specific_energy <-

--- a/R/tool_fix_IEA_data_for_Industry_subsectors.R
+++ b/R/tool_fix_IEA_data_for_Industry_subsectors.R
@@ -1,30 +1,30 @@
 #' Apply corrections to IEA data needed for Industry subsectors
-#' 
-#' Apply corrections to IEA data to cope with fragmentary time series and 
-#' replace outputs from blast furnaces and coke ovens, that are inputs into 
-#' industry subsectors, by their respective inputs.  
+#'
+#' Apply corrections to IEA data to cope with fragmentary time series and
+#' replace outputs from blast furnaces and coke ovens, that are inputs into
+#' industry subsectors, by their respective inputs.
 #' The corrections done by this function are rather rudimentary and crude. This
-#' gets smoothed away in regional aggregation. But do not use the resulting 
+#' gets smoothed away in regional aggregation. But do not use the resulting
 #' country-level data without additional scrutiny.
-#' 
+#'
 #' Use regional or global averages if IEA industry data lists energy use only as
-#' "non-specified". 
+#' "non-specified".
 #' Outputs from blast furnaces (`BLFURGS`, `OGASES`) and coke ovens (`OVENCOKE`,
 #' `COKEOVGS`, `COALTAR`, `NONCRUDE`), that are inputs into industry subsectors.
 #' Used internally in [`calcIO()`] for subtype `output_Industry_subsectors`.
 #'
 #' @md
 #' @param data MAgPIE object containing the IEA Energy Balances data
-#' 
-#' @param ieamatch mapping of IEA product/flow combinations to REMIND 
+#'
+#' @param ieamatch mapping of IEA product/flow combinations to REMIND
 #'        `sety`/`fety`/`te` combinations as used in [`calcIO()`]
 #'
 #' @return a MAgPIE object
-#' 
+#'
 #' @author Michaja Pehl
-#' 
+#'
 #' @importFrom assertr not_na assert
-#' @importFrom dplyr anti_join group_by inner_join left_join mutate pull rename 
+#' @importFrom dplyr anti_join group_by inner_join left_join mutate pull rename
 #'     select summarise
 #' @importFrom magclass getRegions getYears getNames
 #' @importFrom readr read_delim cols col_skip col_character
@@ -35,26 +35,478 @@
 #' @importFrom tidyr complete gather nesting spread
 
 tool_fix_IEA_data_for_Industry_subsectors <- function(data, ieamatch) {
-  
+
   . <- NULL
-  
+
+  # replace coke oven and blast furnace outputs ----
+  .clean_data <- function(m, keep_zeros = FALSE) {
+    m %>%
+      as.data.frame() %>%
+      as_tibble() %>%
+      select(iso3c = 'Region', year = 'Year', product = 'Data1', flow = 'Data2',
+             value = 'Value') %>%
+      filter(0 != .data$value | keep_zeros) %>%
+      character.data.frame() %>%
+      mutate(year = as.integer(.data$year))
+  }
+
+  ## flow definitions ----
+  IEA_flows <- tribble(
+    ~summary.flow,   ~flow,
+    # Total Primary Energy Production
+    'TPES',          'INDPROD',    # primary energy production
+    'TPES',          'IMPORTS',
+    'TPES',          'EXPORTS',
+    'TPES',          'MARBUNK',    # international marine bunkers
+    'TPES',          'AVBUNK',     # international aviation bunkers
+    NA_character_,   'TRANSFER',   # inter-product transfers, product transfers,
+    # and recycling
+    'TPES',          'STOCKCHA',   # stock changes
+
+    # Transformation Processes
+    'TOTTRANF',      'MAINELEC',    # main activity producer electricity plants
+    'TOTTRANF',      'AUTOELEC',    # autoproducer electricity plants
+    'TOTTRANF',      'MAINCHP',     # main activity producer CHP plants
+    'TOTTRANF',      'AUTOCHP',     # autoproducer electricity plants
+    'TOTTRANF',      'MAINHEAT',    # main activity producer heat plants
+    'TOTTRANF',      'AUTOHEAT',    # autoproducer heat plants
+    'TOTTRANF',      'THEAT',       # heat pumps
+    'TOTTRANF',      'TBOILER',     # electric boilers
+    'TOTTRANF',      'TELE',        # chemical heat for electricity production
+    'TOTTRANF',      'TBLASTFUR',   # blast furnaces
+    'TOTTRANF',      'TGASWKS',     # gas works
+    'TOTTRANF',      'TCOKEOVS',    # coke ovens
+    'TOTTRANF',      'TPATFUEL',    # patent fuel plants
+    'TOTTRANF',      'TBKB',        # peat briquette plants
+    'TOTTRANF',      'TREFINER',    # oil refineries
+    'TOTTRANF',      'TPETCHEM',    # petrochemical plants
+    'TOTTRANF',      'TCOALLIQ',    # coal liquefaction plants
+    'TOTTRANF',      'TGTL',        # gas-to-liquid plants
+    'TOTTRANF',      'TBLENDGAS',   # blended natural gas
+    'TOTTRANF',      'TCHARCOAL',   # charcoal production plants
+    'TOTTRANF',      'TNONSPEC',    # non-specified transformation
+
+    # Energy Industry Own Use and Losses
+    'TOTENGY',       'EMINES',      # coal mines
+    'TOTENGY',       'EOILGASEX',   # oil and gas extraction
+    'TOTENGY',       'EBLASTFUR',   # blast furnaces
+    'TOTENGY',       'EGASWKS',     # gas works
+    'TOTENGY',       'EBIOGAS',     # gasifications plants for biogases
+    'TOTENGY',       'ECOKEOVS',    # coke ovens
+    'TOTENGY',       'EPATFUEL',    # patent fuel plants
+    'TOTENGY',       'EBKB',        # peat briquette plants
+    'TOTENGY',       'EREFINER',    # oil refineries
+    'TOTENGY',       'ECOALLIQ',    # coal liquefaction plants
+    'TOTENGY',       'ELNG',        # liquefaction/regasification plants
+    'TOTENGY',       'EGTL',        # gas-to-liquied plants
+    'TOTENGY',       'EPOWERPLT',   # own use in electricity, CHP, and heat
+    # plants
+    'TOTENGY',       'EPUMPST',     # pumped storage plants
+    'TOTENGY',       'ENUC',        # nuclear industry
+    'TOTENGY',       'ECHARCOAL',   # charcoal production plants
+    'TOTENGY',       'ENONSPEC',    # non-specified energy industry
+    'TOTENGY',       'DISTLOSS',    # distribution and transmission losses
+
+    # Final Consumption
+    'TFC',           'IRONSTL',    # iron and steel
+    'TFC',           'CHEMICAL',   # chemical and petrochemical
+    'TFC',           'NONFERR',    # non-ferrous metals
+    'TFC',           'NONMET',     # non-metallic minerals
+    'TFC',           'TRANSEQ',    # transport equipment
+    'TFC',           'MACHINE',    # machinery
+    'TFC',           'MINING',     # mining and quarrying
+    'TFC',           'FOODPRO',    # food production
+    'TFC',           'PAPERPRO',   # paper, pulp, and print
+    'TFC',           'WOODPRO',    # wood and wood products
+    'TFC',           'CONSTRUC',   # construction
+    'TFC',           'TEXTILES',   # textiles
+    'TFC',           'INONSPEC',   # non-specified industry
+    'TFC',           'WORLDAV',    # world aviation bunkers
+    'TFC',           'DOMESAIR',   # domestic aviation
+    'TFC',           'ROAD',       # road
+    'TFC',           'RAIL',       # rail
+    'TFC',           'PIPELINE',   # pipeline transport
+    'TFC',           'WORLDMAR',   # world marine bunkers
+    'TFC',           'DOMESNAV',   # domestic navigation
+    'TFC',           'TRNONSPE',   # non-specified transport
+    'TFC',           'RESIDENT',   # residential
+    'TFC',           'COMMPUB',    # commercial and public services
+    'TFC',           'AGRICULT',   # agriculture/forestry
+    'TFC',           'FISHING',    # fishing
+    'TFC',           'ONONSPEC',   # non-specified other consumption
+
+
+    'TOTIND',        'IRONSTL',    # iron and steel
+    'TOTIND',        'CHEMICAL',   # chemical and petrochemical
+    'TOTIND',        'NONFERR',    # non-ferrous metals
+    'TOTIND',        'NONMET',     # non-metallic minerals
+    'TOTIND',        'TRANSEQ',    # transport equipment
+    'TOTIND',        'MACHINE',    # machinery
+    'TOTIND',        'MINING',     # mining and quarrying
+    'TOTIND',        'FOODPRO',    # food production
+    'TOTIND',        'PAPERPRO',   # paper, pulp, and print
+    'TOTIND',        'WOODPRO',    # wood and wood products
+    'TOTIND',        'CONSTRUC',   # construction
+    'TOTIND',        'TEXTILES',   # textiles
+    'TOTIND',        'INONSPEC',   # non-specified industry
+
+    # Transport
+    'TOTTRANS',      'WORLDAV',    # world aviation bunkers
+    'TOTTRANS',      'DOMESAIR',   # domestic aviation
+    'TOTTRANS',      'ROAD',       # road
+    'TOTTRANS',      'RAIL',       # rail
+    'TOTTRANS',      'PIPELINE',   # pipeline transport
+    'TOTTRANS',      'WORLDMAR',   # world marine bunkers
+    'TOTTRANS',      'DOMESNAV',   # domestic navigation
+    'TOTTRANS',      'TRNONSPE',   # non-specified transport
+
+    # Other Consumption
+    'TOTOTHER',      'RESIDENT',   # residential
+    'TOTOTHER',      'COMMPUB',    # commercial and public services
+    'TOTOTHER',      'AGRICULT',   # agriculture/forestry
+    'TOTOTHER',      'FISHING',    # fishing
+    'TOTOTHER',      'ONONSPEC',   # non-specified other consumption
+
+    # Non-Energy Use
+    'NONENUSE',      'NEINTREN',   # non-energy use in industry/transformation/
+    # energy
+    NA_character_,   'NECHEM',     # non-energy use chemical/petrochemical
+    'NONENUSE',      'NETRANS',    # non-energy use in transport
+    'NONENUSE',      'NEOTHER',    # non-energy use in other
+
+    # Electricity Output
+    'ELOUTPUT',      'ELMAINE',   # main activity producer electricity plants
+    'ELOUTPUT',      'ELAUTOE',   # autoproducer electricity plants
+    'ELOUTPUT',      'ELMAINC',   # main activity producer CHP plants
+    'ELOUTPUT',      'ELAUTOC',   # autoproducer CHP plants
+
+    # Heat Output
+    'HEATOUT',       'HEMAINC',   # main activity producer CHP plants
+    'HEATOUT',       'HEAUTOC',   # autoproducer CHP plants
+    'HEATOUT',       'HEMAINH',   # main activity producer heat plants
+    'HEATOUT',       'HEAUTOH'    # autoproducer heat plants
+  )
+
+  base_flows <- unique(IEA_flows$flow)
+  summary_flows <- unique(na.omit(IEA_flows$summary.flow))
+  all_flows <- c(base_flows, summary_flows)
+
+  ### blast furnace flows to be replaced ----
+  # all transformation, energy system and final consumption flows, except for
+  # those related to blast furnaces
+  flow_BLASTFUR_to_replace <- setdiff(all_flows, c('EBLASTFUR', 'TBLASTFUR'))
+
+  ### coke oven flows to be replaced ----
+  # all transformation, energy system and final consumption flows, except for
+  # those related to coke ovens
+  flow_COKEOVS_to_replace <- setdiff(all_flows, c('ECOKEOVS', 'TCOKEOVS'))
+
+  ## blast furnace data ----
+  # all products in/out of blast furnace transformation and energy demand, except
+  # summary flows 'TOTAL' and 'MRENEW'
+  data_BLASTFUR <- data %>%
+    `[`(,, c('EBLASTFUR', 'TBLASTFUR'), pmatch = 'right') %>%
+    `[`(,, c('TOTAL', 'MRENEW'), pmatch = 'left', invert = TRUE) %>%
+    .clean_data() %>%
+    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop')
+
+  ### blast furnace inputs ----
+  # inputs into transformation/energy system are negative
+  data_BLASTFUR_inputs <- data_BLASTFUR %>%
+    filter(0 > .data$value)
+
+  ### blast furnace outputs ----
+  # outputs from transformation are positive
+  data_BLASTFUR_outputs <- data_BLASTFUR %>%
+    filter(0 < .data$value)
+
+  ### blast furnace output products ----
+  # products blast furnaces supply to other flows
+  outputs_BLASTFUR <- data_BLASTFUR_outputs %>%
+    pull('product') %>%
+    unique()
+
+  ### product/flow to be replaced ----
+  # all blast furnace outputs and flows to be replaced, that are actually present
+  # in the data
+  product_flow_BLASTFUR_to_replace <- intersect(
+    cartesian(outputs_BLASTFUR, flow_BLASTFUR_to_replace),
+    getNames(data))
+
+  ### blast furnace product use ----
+  data_BLASTFUR_use <- data %>%
+    `[`(,, product_flow_BLASTFUR_to_replace) %>%
+    .clean_data()
+
+  ## blast furnace replacement data ----
+  # outputs are replaced joule-by-joule with inputs, according to the input shares
+  # right_join() filters out countries/years that do not use blast furnace
+  # products
+  data_BLASTFUR_replacement <- right_join(
+    data_BLASTFUR_inputs %>%
+      group_by(!!!syms(c('iso3c', 'year'))) %>%
+      mutate(factor = .data$value / sum(.data$value)) %>%
+      ungroup() %>%
+      select(-'value'),
+
+    data_BLASTFUR_use %>%
+      select(-'product'),
+
+    c('iso3c', 'year')
+  ) %>%
+    # FIXME: filter countries/years that have no inputs into blast furnaces, yet
+    # outputs from them and use of blast furnace products (e.g. ISR 1973)
+    filter(!is.na(.data$product)) %>%
+    assert(not_na, everything(),
+           description = 'Only valid blast furnace replacement data') %>%
+    mutate(value = .data$value * .data$factor) %>%
+    group_by(!!!syms(c('iso3c', 'year', 'product', 'flow'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop')
+
+  ## coke oven data ----
+  # all products in/out of coke oven transformation and energy demand, except
+  # summary flows 'TOTAL' and 'MRENEW'
+  data_COKEOVS <- data %>%
+    `[`(,, c('ECOKEOVS', 'TCOKEOVS'), pmatch = 'right') %>%
+    `[`(,, c('TOTAL', 'MRENEW'), pmatch = 'left', invert = TRUE) %>%
+    .clean_data() %>%
+    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop')
+
+  #### apply blast furnace replacement ----
+  # Coke ovens and blast furnaces can be both inputs and outputs to one another at
+  # the same time.  To untangle this, we first replace blast furnace outputs that
+  # are inputs into coke ovens by coke oven outputs, which are netted with the
+  # direct outputs (here), and then replace coke oven outputs that are blast
+  # furnace inputs by coke oven inputs (further below).
+  data_COKEOVS <- bind_rows(
+    data_COKEOVS %>%
+      filter(!.data$product %in% outputs_BLASTFUR),
+
+    data_BLASTFUR_replacement %>%
+      filter(.data$flow %in% c('ECOKEOVS', 'TCOKEOVS')) %>%
+      select(-'flow')
+  ) %>%
+    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop')
+
+  ### coke oven inputs ----
+  # inputs into transformation/energy system are negative
+  data_COKEOVS_inputs <- data_COKEOVS %>%
+    filter(0 > .data$value)
+
+  ### coke oven outputs ----
+  # outputs from transformation are positive
+  data_COKEOVS_outputs <- data_COKEOVS %>%
+    filter(0 < .data$value)
+
+  ### coke oven output products ----
+  # products coke ovens supply to other flows
+  outputs_COKEOVS <- data_COKEOVS_outputs %>%
+    pull('product') %>%
+    unique()
+
+  ### product/flows to be replaced ----
+  # all coke oven outputs and flows to be replaced, that are actually present in
+  # the data
+  product_flow_COKEOVS_to_replace <- intersect(
+    cartesian(outputs_COKEOVS, flow_COKEOVS_to_replace),
+    getNames(data))
+
+  ### coke oven product use ----
+  data_COKEOVS_use <- data %>%
+    `[`(,, product_flow_COKEOVS_to_replace) %>%
+    .clean_data()
+
+  ## coke oven replacement data ----
+  # outputs are replaced joule-by-joule with inputs, according to the input shares
+  # right_join() filters out countries/years that do not use coke oven products
+  data_COKEOVS_replacement <- right_join(
+    data_COKEOVS_inputs %>%
+      group_by(!!!syms(c('iso3c', 'year'))) %>%
+      mutate(factor = .data$value / sum(.data$value)) %>%
+      ungroup() %>%
+      select(-'value'),
+
+    data_COKEOVS_use %>%
+      select(-'product'),
+
+    c('iso3c', 'year')
+  ) %>%
+    # FIXME: filter countries/year that have no inputs into coke ovens but use
+    # coke oven outputs (which most likely are imported)
+    filter(!is.na(.data$product)) %>%
+    assert(not_na, everything(),
+           description = 'Only valid coke oven replacement data') %>%
+    mutate(value = .data$value * .data$factor) %>%
+    select('iso3c', 'year', 'product', 'flow', 'value')
+
+  ## coke oven loss data ----
+  # coke oven losses (true losses from ECOKEOVS and transformation energy from
+  # TCOKEOVS) are allotted to the IRONSTL sector
+  # losses are the difference of inputs and outputs, weighted by input shares
+  # right_join() filters out countries/years that do not use coke oven products
+  data_COKEOVS_loss <- right_join(
+    data_COKEOVS_inputs,
+
+    data_COKEOVS_outputs %>%
+      group_by(!!!syms(c('iso3c', 'year'))) %>%
+      summarise(output = sum(.data$value), .groups = 'drop'),
+
+    c('iso3c', 'year')
+  ) %>%
+    # FIXME: filter countries/year that have no inputs into coke ovens but use
+    # coke oven outputs (which most likely are imported)
+    filter(!is.na(.data$product)) %>%
+    assert(not_na, everything(),
+           description = 'Only valid coke oven loss data') %>%
+    group_by(!!!syms(c('iso3c', 'year'))) %>%
+    mutate(value = (sum(-.data$value) - .data$output)
+           * .data$value / sum(.data$value),
+           flow = 'IRONSTL') %>%
+    ungroup() %>%
+    select('iso3c', 'year', 'product', 'flow', 'value')
+
+  ## recalculate blast furnace inputs w/ coke oven replacements ----
+
+  #### apply coke oven replacement ----
+  # Coke ovens and blast furnaces can be both inputs and outputs to one another at
+  # the same time.  To untangle this, we first replace blast furnace outputs that
+  # are inputs into coke ovens by coke oven outputs, which are netted with the
+  # direct outputs (above), and then replace coke oven outputs that are blast
+  # furnace inputs by coke oven inputs (here).
+  data_BLASTFUR <- bind_rows(
+    data_BLASTFUR %>%
+      filter(!.data$product %in% outputs_COKEOVS),
+
+    data_COKEOVS_replacement %>%
+      filter(.data$flow %in% c('EBLATFUR', 'TBLASTFUR')) %>%
+      select(-'flow')
+  ) %>%
+    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop')
+
+  ### blast furnace inputs ----
+  # inputs into transformation/energy system are negative
+  data_BLASTFUR_inputs <- data_BLASTFUR %>%
+    filter(0 > .data$value)
+
+  ### blast furnace replacement data ----
+  # outputs are replaced joule-by-joule with inputs, according to the input shares
+  # right_join() filters out countries/years that do not use blast furnace
+  # products
+  data_BLASTFUR_replacement <- right_join(
+    data_BLASTFUR_inputs %>%
+      group_by(!!!syms(c('iso3c', 'year'))) %>%
+      mutate(factor = .data$value / sum(.data$value)) %>%
+      ungroup() %>%
+      select(-'value'),
+
+    data_BLASTFUR_use %>%
+      select(-'product'),
+
+    c('iso3c', 'year')
+  ) %>%
+    # FIXME: filter countries/years that have no inputs into blast furnaces, yet
+    # outputs from them and use of blast furnace products (e.g. ISR 1973)
+    filter(!is.na(.data$product)) %>%
+    assert(not_na, everything(),
+           description = 'Only valid blast furnace replacement data') %>%
+    mutate(value = .data$value * .data$factor) %>%
+    group_by(!!!syms(c('iso3c', 'year', 'product', 'flow'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop')
+
+  ## blast furnace loss data ----
+  # blast furnace losses (true losses from EBLASTFUR and transformation energy
+  # from TBLASTFUR) are allotted to the IRONSTL sector
+  # losses are the difference of inputs and outputs, weighted by input shares
+  # right_join() filters out countries/years that do not use blast furnace
+  # products
+  data_BLASTFUR_loss <- right_join(
+    data_BLASTFUR_inputs,
+
+    data_BLASTFUR_outputs %>%
+      group_by(!!!syms(c('iso3c', 'year'))) %>%
+      summarise(output = sum(.data$value), .groups = 'drop'),
+
+    c('iso3c', 'year')
+  ) %>%
+    # FIXME: filter countries/years that have no inputs into blast furnaces, yet
+    # outputs from them and use of blast furnace products (e.g. ISR 1973)
+    filter(!is.na(.data$product)) %>%
+    assert(not_na, everything(),
+           description = 'Only valid blast furnace loss data') %>%
+    group_by(!!!syms(c('iso3c', 'year'))) %>%
+    mutate(value = (sum(-.data$value) - .data$output)
+           * .data$value / sum(.data$value),
+           flow = 'IRONSTL') %>%
+    ungroup() %>%
+    select('iso3c', 'year', 'product', 'flow', 'value')
+
+  ## replace coke oven and blast furnace products ----
+  data_replace <- bind_rows(
+    # filter already replaced data
+    data_COKEOVS_replacement %>%
+      filter(!.data$flow %in% c('EBLATFUR', 'TBLASTFUR')),
+
+    data_BLASTFUR_replacement %>%
+      filter(!.data$flow %in% c('ECOKEOVS', 'TCOKEOVS')),
+
+    data_COKEOVS_loss %>%
+      sum_total_('product', name = 'TOTAL'),
+
+    data_BLASTFUR_loss %>%
+      sum_total_('product', name = 'TOTAL')
+  ) %>%
+    group_by(!!!syms(setdiff(colnames(.), 'value'))) %>%
+    summarise(value = sum(.data$value), .groups = 'drop') %>%
+    arrange(!!!syms(c('iso3c', 'year', 'product', 'flow'))) %>%
+    as.magpie(spatial = 1, temporal = 2, data = ncol(.))
+
+  data_replace[is.na(data_replace)] <- 0
+
+  regions_keep <- sort(getRegions(data))
+  years_keep   <- sort(getYears(data))
+  names_keep   <- sort(setdiff(getNames(data),
+                               c(product_flow_COKEOVS_to_replace,
+                                 product_flow_BLASTFUR_to_replace)))
+
+  regions_replace <- sort(getRegions(data_replace))
+  years_replace   <- sort(getYears(data_replace))
+  names_replace   <- sort(getNames(data_replace))
+
+  data_fixed <- new.magpie(cells_and_regions = regions_keep, years = years_keep,
+                           names = unique(c(names_keep, names_replace)),
+                           fill = 0)
+
+  data_fixed[regions_keep,years_keep,names_keep] <- data %>%
+    `[`(regions_keep, years_keep, names_keep)
+
+  data_fixed[regions_replace,years_replace,names_replace] <- (
+      data_fixed[regions_replace,years_replace,names_replace]
+    + data_replace[regions_replace,years_replace,names_replace]
+  )
+
+  data <- data_fixed
+
   # all industry subsector flows
-  flows_to_fix <- c('IRONSTL', 'CHEMICAL', 'NONFERR', 'NONMET', 'TRANSEQ', 
-                    'MACHINE','MINING', 'FOODPRO', 'PAPERPRO', 'WOODPRO', 
+  flows_to_fix <- c('IRONSTL', 'CHEMICAL', 'NONFERR', 'NONMET', 'TRANSEQ',
+                    'MACHINE','MINING', 'FOODPRO', 'PAPERPRO', 'WOODPRO',
                     'CONSTRUC', 'TEXTILES')
-  
+
   # all products associated with those flows
   products_to_fix <- ieamatch %>%
     filter(.data$iea_flows %in% flows_to_fix) %>%
     getElement('iea_product') %>%
     unique()
 
-  region_mapping <- toolGetMapping(name = 'regionmapping_21_EU11.csv', 
-                                   type = 'regional') %>% 
-    as_tibble() %>% 
+  region_mapping <- toolGetMapping(name = 'regionmapping_21_EU11.csv',
+                                   type = 'regional') %>%
+    as_tibble() %>%
     select('iso3c' = .data$CountryCode, 'region' = .data$RegionCode)
 
-  # ---- extend industry subsector time series ----
+  # extend industry subsector time series ----
   # subset of data containing industry subsector products and flows
   data_industry <- data[,,cartesian(products_to_fix,
                                     c(flows_to_fix, 'TOTIND', 'INONSPEC'))] %>%
@@ -80,11 +532,11 @@ tool_fix_IEA_data_for_Industry_subsectors <- function(data, ieamatch) {
 
     c('iso3c', 'region', 'year', 'product')
   ) %>%
-    filter(  abs(1 - (.data$total / .data$TOTIND)) > 1e-3 
-           | .data$INONSPEC == .data$TOTIND) %>%
+    # abs(1 - (.data$total / .data$TOTIND)) > 1e-3 |
+    filter(.data$INONSPEC == .data$TOTIND) %>%
     select(.data$iso3c, .data$region, .data$year, .data$product, .data$TOTIND)
 
-  # use all non-suspicious data to calculate reginal and global averages
+  # use all non-suspicious data to calculate regional and global averages
   data_for_fixing <- anti_join(
     data_industry %>%
       filter('TOTIND' != .data$flow),
@@ -93,7 +545,7 @@ tool_fix_IEA_data_for_Industry_subsectors <- function(data, ieamatch) {
       select(-.data$TOTIND),
 
     c('iso3c', 'region', 'year', 'product')
-  ) %>% 
+  ) %>%
     as_tibble()
 
   data_for_fixing <- full_join(
@@ -124,9 +576,9 @@ tool_fix_IEA_data_for_Industry_subsectors <- function(data, ieamatch) {
                           .data$global_share)) %>%
     select(-.data$regional_share, -.data$global_share) %>%
     interpolate_missing_periods_(
-      periods = list(year = sub('^y([0-9]{4})$', '\\1', getYears(data)) %>% 
-                       as.integer() %>% 
-                       sort()), 
+      periods = list(year = sub('^y([0-9]{4})$', '\\1', getYears(data)) %>%
+                       as.integer() %>%
+                       sort()),
       expand.values = TRUE, method = 'linear')
 
   # calculated fixed data
@@ -137,11 +589,11 @@ tool_fix_IEA_data_for_Industry_subsectors <- function(data, ieamatch) {
   ) %>%
     # replace "suspicious" data with averages
     mutate(value = .data$TOTIND * .data$value) %>%
-    select(.data$iso3c, .data$region, .data$year, .data$product, .data$flow, 
+    select(.data$iso3c, .data$region, .data$year, .data$product, .data$flow,
            .data$value) %>%
     assert(not_na, .data$value) %>%
     overwrite(data_industry) %>%
-    select(COUNTRY = .data$iso3c, TIME = .data$year, PRODUCT = .data$product, 
+    select(COUNTRY = .data$iso3c, TIME = .data$year, PRODUCT = .data$product,
            FLOW = .data$flow, Value = .data$value) %>%
     as.magpie()
 
@@ -149,456 +601,6 @@ tool_fix_IEA_data_for_Industry_subsectors <- function(data, ieamatch) {
   data[getRegions(data_industry_fixed),
        getYears(data_industry_fixed),
        getNames(data_industry_fixed)] <- data_industry_fixed
-  
-  # replace coke oven and blast furnace outputs ----
-  .clean_data <- function(m, keep_zeros = FALSE) {
-    m %>% 
-      as.data.frame() %>% 
-      as_tibble() %>% 
-      select(iso3c = 'Region', year = 'Year', product = 'Data1', flow = 'Data2', 
-             value = 'Value') %>% 
-      filter(0 != .data$value | keep_zeros) %>% 
-      character.data.frame() %>% 
-      mutate(year = as.integer(.data$year))
-  }
-  
-  ## flow definitions ----
-  IEA_flows <- tribble(
-    ~summary.flow,   ~flow,
-    # Total Primary Energy Production
-    'TPES',          'INDPROD',    # primary energy production
-    'TPES',          'IMPORTS',
-    'TPES',          'EXPORTS',
-    'TPES',          'MARBUNK',    # international marine bunkers
-    'TPES',          'AVBUNK',     # international aviation bunkers
-    NA_character_,   'TRANSFER',   # inter-product transfers, product transfers,
-                                   # and recycling
-    'TPES',          'STOCKCHA',   # stock changes
-    
-    # Transformation Processes
-    'TOTTRANF',      'MAINELEC',    # main activity producer electricity plants
-    'TOTTRANF',      'AUTOELEC',    # autoproducer electricity plants
-    'TOTTRANF',      'MAINCHP',     # main activity producer CHP plants
-    'TOTTRANF',      'AUTOCHP',     # autoproducer electricity plants
-    'TOTTRANF',      'MAINHEAT',    # main activity producer heat plants
-    'TOTTRANF',      'AUTOHEAT',    # autoproducer heat plants
-    'TOTTRANF',      'THEAT',       # heat pumps
-    'TOTTRANF',      'TBOILER',     # electric boilers
-    'TOTTRANF',      'TELE',        # chemical heat for electricity production
-    'TOTTRANF',      'TBLASTFUR',   # blast furnaces
-    'TOTTRANF',      'TGASWKS',     # gas works
-    'TOTTRANF',      'TCOKEOVS',    # coke ovens
-    'TOTTRANF',      'TPATFUEL',    # patent fuel plants
-    'TOTTRANF',      'TBKB',        # peat briquette plants
-    'TOTTRANF',      'TREFINER',    # oil refineries
-    'TOTTRANF',      'TPETCHEM',    # petrochemical plants
-    'TOTTRANF',      'TCOALLIQ',    # coal liquefaction plants
-    'TOTTRANF',      'TGTL',        # gas-to-liquid plants
-    'TOTTRANF',      'TBLENDGAS',   # blended natural gas
-    'TOTTRANF',      'TCHARCOAL',   # charcoal production plants
-    'TOTTRANF',      'TNONSPEC',    # non-specified transformation
-    
-    # Energy Industry Own Use and Losses
-    'TOTENGY',       'EMINES',      # coal mines
-    'TOTENGY',       'EOILGASEX',   # oil and gas extraction
-    'TOTENGY',       'EBLASTFUR',   # blast furnaces
-    'TOTENGY',       'EGASWKS',     # gas works
-    'TOTENGY',       'EBIOGAS',     # gasifications plants for biogases
-    'TOTENGY',       'ECOKEOVS',    # coke ovens
-    'TOTENGY',       'EPATFUEL',    # patent fuel plants
-    'TOTENGY',       'EBKB',        # peat briquette plants
-    'TOTENGY',       'EREFINER',    # oil refineries
-    'TOTENGY',       'ECOALLIQ',    # coal liquefaction plants
-    'TOTENGY',       'ELNG',        # liquefaction/regasification plants
-    'TOTENGY',       'EGTL',        # gas-to-liquied plants
-    'TOTENGY',       'EPOWERPLT',   # own use in electricity, CHP, and heat 
-                                    # plants
-    'TOTENGY',       'EPUMPST',     # pumped storage plants
-    'TOTENGY',       'ENUC',        # nuclear industry
-    'TOTENGY',       'ECHARCOAL',   # charcoal production plants
-    'TOTENGY',       'ENONSPEC',    # non-specified energy industry
-    'TOTENGY',       'DISTLOSS',    # distribution and transmission losses
-    
-    # Final Consumption
-    'TFC',           'IRONSTL',    # iron and steel
-    'TFC',           'CHEMICAL',   # chemical and petrochemical
-    'TFC',           'NONFERR',    # non-ferrous metals
-    'TFC',           'NONMET',     # non-metallic minerals
-    'TFC',           'TRANSEQ',    # transport equipment
-    'TFC',           'MACHINE',    # machinery
-    'TFC',           'MINING',     # mining and quarrying
-    'TFC',           'FOODPRO',    # food production
-    'TFC',           'PAPERPRO',   # paper, pulp, and print
-    'TFC',           'WOODPRO',    # wood and wood products
-    'TFC',           'CONSTRUC',   # construction
-    'TFC',           'TEXTILES',   # textiles
-    'TFC',           'INONSPEC',   # non-specified industry
-    'TFC',           'WORLDAV',    # world aviation bunkers
-    'TFC',           'DOMESAIR',   # domestic aviation
-    'TFC',           'ROAD',       # road
-    'TFC',           'RAIL',       # rail
-    'TFC',           'PIPELINE',   # pipeline transport
-    'TFC',           'WORLDMAR',   # world marine bunkers
-    'TFC',           'DOMESNAV',   # domestic navigation
-    'TFC',           'TRNONSPE',   # non-specified transport
-    'TFC',           'RESIDENT',   # residential
-    'TFC',           'COMMPUB',    # commercial and public services
-    'TFC',           'AGRICULT',   # agriculture/forestry
-    'TFC',           'FISHING',    # fishing
-    'TFC',           'ONONSPEC',   # non-specified other consumption
-    
-    
-    'TOTIND',        'IRONSTL',    # iron and steel
-    'TOTIND',        'CHEMICAL',   # chemical and petrochemical
-    'TOTIND',        'NONFERR',    # non-ferrous metals
-    'TOTIND',        'NONMET',     # non-metallic minerals
-    'TOTIND',        'TRANSEQ',    # transport equipment
-    'TOTIND',        'MACHINE',    # machinery
-    'TOTIND',        'MINING',     # mining and quarrying
-    'TOTIND',        'FOODPRO',    # food production
-    'TOTIND',        'PAPERPRO',   # paper, pulp, and print
-    'TOTIND',        'WOODPRO',    # wood and wood products
-    'TOTIND',        'CONSTRUC',   # construction
-    'TOTIND',        'TEXTILES',   # textiles
-    'TOTIND',        'INONSPEC',   # non-specified industry
-    
-    # Transport
-    'TOTTRANS',      'WORLDAV',    # world aviation bunkers
-    'TOTTRANS',      'DOMESAIR',   # domestic aviation
-    'TOTTRANS',      'ROAD',       # road
-    'TOTTRANS',      'RAIL',       # rail
-    'TOTTRANS',      'PIPELINE',   # pipeline transport
-    'TOTTRANS',      'WORLDMAR',   # world marine bunkers
-    'TOTTRANS',      'DOMESNAV',   # domestic navigation
-    'TOTTRANS',      'TRNONSPE',   # non-specified transport
-    
-    # Other Consumption
-    'TOTOTHER',      'RESIDENT',   # residential
-    'TOTOTHER',      'COMMPUB',    # commercial and public services
-    'TOTOTHER',      'AGRICULT',   # agriculture/forestry
-    'TOTOTHER',      'FISHING',    # fishing
-    'TOTOTHER',      'ONONSPEC',   # non-specified other consumption
-    
-    # Non-Energy Use
-    'NONENUSE',      'NEINTREN',   # non-energy use in industry/transformation/
-                                   # energy
-    NA_character_,   'NECHEM',     # non-energy use chemical/petrochemical
-    'NONENUSE',      'NETRANS',    # non-energy use in transport
-    'NONENUSE',      'NEOTHER',    # non-energy use in other
-    
-    # Electricity Output
-    'ELOUTPUT',      'ELMAINE',   # main activity producer electricity plants
-    'ELOUTPUT',      'ELAUTOE',   # autoproducer electricity plants
-    'ELOUTPUT',      'ELMAINC',   # main activity producer CHP plants
-    'ELOUTPUT',      'ELAUTOC',   # autoproducer CHP plants
-    
-    # Heat Output
-    'HEATOUT',       'HEMAINC',   # main activity producer CHP plants
-    'HEATOUT',       'HEAUTOC',   # autoproducer CHP plants
-    'HEATOUT',       'HEMAINH',   # main activity producer heat plants
-    'HEATOUT',       'HEAUTOH'    # autoproducer heat plants
-    )
-  
-  base_flows <- unique(IEA_flows$flow)
-  summary_flows <- unique(na.omit(IEA_flows$summary.flow))
-  all_flows <- c(base_flows, summary_flows)
-  
-  ### blast furnace flows to be replaced ---- 
-  # all transformation, energy system and final consumption flows, except for 
-  # those related to blast furnaces
-  flow_BLASTFUR_to_replace <- setdiff(all_flows, c('EBLASTFUR', 'TBLASTFUR'))
-  
-  ### coke oven flows to be replaced ----
-  # all transformation, energy system and final consumption flows, except for 
-  # those related to coke ovens
-  flow_COKEOVS_to_replace <- setdiff(all_flows, c('ECOKEOVS', 'TCOKEOVS'))
-  
-  ## blast furnace data ----
-  # all products in/out of blast furnace transformation and energy demand, except
-  # summary flows 'TOTAL' and 'MRENEW'
-  data_BLASTFUR <- data %>% 
-    `[`(,, c('EBLASTFUR', 'TBLASTFUR'), pmatch = 'right') %>% 
-    `[`(,, c('TOTAL', 'MRENEW'), pmatch = 'left', invert = TRUE) %>% 
-    .clean_data() %>% 
-    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>% 
-    summarise(value = sum(.data$value), .groups = 'drop')
-  
-  ### blast furnace inputs ----
-  # inputs into transformation/energy system are negative
-  data_BLASTFUR_inputs <- data_BLASTFUR %>% 
-    filter(0 > .data$value)
-  
-  ### blast furnace outputs ----
-  # outputs from transformation are positive
-  data_BLASTFUR_outputs <- data_BLASTFUR %>% 
-    filter(0 < .data$value)
-  
-  ### blast furnace output products ----
-  # products blast furnaces supply to other flows
-  outputs_BLASTFUR <- data_BLASTFUR_outputs %>% 
-    pull('product') %>% 
-    unique()
-  
-  ### product/flow to be replaced ---- 
-  # all blast furnace outputs and flows to be replaced, that are actually present
-  # in the data
-  product_flow_BLASTFUR_to_replace <- intersect(
-    cartesian(outputs_BLASTFUR, flow_BLASTFUR_to_replace),
-    getNames(data))
-  
-  ### blast furnace product use ----
-  data_BLASTFUR_use <- data %>% 
-    `[`(,, product_flow_BLASTFUR_to_replace) %>% 
-    .clean_data()
-  
-  ## blast furnace replacement data ----
-  # outputs are replaced joule-by-joule with inputs, according to the input shares
-  # right_join() filters out countries/years that do not use blast furnace 
-  # products
-  data_BLASTFUR_replacement <- right_join(
-    data_BLASTFUR_inputs %>% 
-      group_by(!!!syms(c('iso3c', 'year'))) %>% 
-      mutate(factor = .data$value / sum(.data$value)) %>% 
-      ungroup() %>% 
-      select(-'value'),
-    
-    data_BLASTFUR_use %>% 
-      select(-'product'),
-    
-    c('iso3c', 'year')
-  ) %>% 
-    # FIXME: filter countries/years that have no inputs into blast furnaces, yet
-    # outputs from them and use of blast furnace products (e.g. ISR 1973)
-    filter(!is.na(.data$product)) %>% 
-    assert(not_na, everything(),
-           description = 'Only valid blast furnace replacement data') %>% 
-    mutate(value = .data$value * .data$factor) %>% 
-    group_by(!!!syms(c('iso3c', 'year', 'product', 'flow'))) %>%
-    summarise(value = sum(.data$value), .groups = 'drop')
-  
-  ## coke oven data ----
-  # all products in/out of coke oven transformation and energy demand, except
-  # summary flows 'TOTAL' and 'MRENEW'
-  data_COKEOVS <- data %>% 
-    `[`(,, c('ECOKEOVS', 'TCOKEOVS'), pmatch = 'right') %>% 
-    `[`(,, c('TOTAL', 'MRENEW'), pmatch = 'left', invert = TRUE) %>% 
-    .clean_data() %>% 
-    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>% 
-    summarise(value = sum(.data$value), .groups = 'drop')
-  
-  #### apply blast furnace replacement ----
-  # Coke ovens and blast furnaces can be both inputs and outputs to one another at
-  # the same time.  To untangle this, we first replace blast furnace outputs that
-  # are inputs into coke ovens by coke oven outputs, which are netted with the
-  # direct outputs (here), and then replace coke oven outputs that are blast 
-  # furnace inputs by coke oven inputs (further below).
-  data_COKEOVS <- bind_rows(
-    data_COKEOVS %>% 
-      filter(!.data$product %in% outputs_BLASTFUR),
-    
-    data_BLASTFUR_replacement %>% 
-      filter(.data$flow %in% c('ECOKEOVS', 'TCOKEOVS')) %>% 
-      select(-'flow')
-  ) %>% 
-    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>% 
-    summarise(value = sum(.data$value), .groups = 'drop')
-  
-  ### coke oven inputs ----
-  # inputs into transformation/energy system are negative
-  data_COKEOVS_inputs <- data_COKEOVS %>% 
-    filter(0 > .data$value)
-  
-  ### coke oven outputs ----
-  # outputs from transformation are positive
-  data_COKEOVS_outputs <- data_COKEOVS %>% 
-    filter(0 < .data$value)
-  
-  ### coke oven output products ----
-  # products coke ovens supply to other flows
-  outputs_COKEOVS <- data_COKEOVS_outputs %>% 
-    pull('product') %>% 
-    unique()
-  
-  ### product/flows to be replaced ----
-  # all coke oven outputs and flows to be replaced, that are actually present in
-  # the data
-  product_flow_COKEOVS_to_replace <- intersect(
-    cartesian(outputs_COKEOVS, flow_COKEOVS_to_replace),
-    getNames(data))
-  
-  ### coke oven product use ----
-  data_COKEOVS_use <- data %>% 
-    `[`(,, product_flow_COKEOVS_to_replace) %>% 
-    .clean_data()
-  
-  ## coke oven replacement data ----
-  # outputs are replaced joule-by-joule with inputs, according to the input shares 
-  # right_join() filters out countries/years that do not use coke oven products
-  data_COKEOVS_replacement <- right_join(
-    data_COKEOVS_inputs %>% 
-      group_by(!!!syms(c('iso3c', 'year'))) %>% 
-      mutate(factor = .data$value / sum(.data$value)) %>% 
-      ungroup() %>% 
-      select(-'value'),
-    
-    data_COKEOVS_use %>% 
-      select(-'product'),
-    
-    c('iso3c', 'year')
-  ) %>% 
-    # FIXME: filter countries/year that have no inputs into coke ovens but use
-    # coke oven outputs (which most likely are imported)
-    filter(!is.na(.data$product)) %>% 
-    assert(not_na, everything(),
-           description = 'Only valid coke oven replacement data') %>% 
-    mutate(value = .data$value * .data$factor) %>% 
-    select('iso3c', 'year', 'product', 'flow', 'value')
-  
-  ## coke oven loss data ----
-  # coke oven losses (true losses from ECOKEOVS and transformation energy from
-  # TCOKEOVS) are allotted to the IRONSTL sector
-  # losses are the difference of inputs and outputs, weighted by input shares
-  # right_join() filters out countries/years that do not use coke oven products
-  data_COKEOVS_loss <- right_join(
-    data_COKEOVS_inputs,
-    
-    data_COKEOVS_outputs %>% 
-      group_by(!!!syms(c('iso3c', 'year'))) %>% 
-      summarise(output = sum(.data$value), .groups = 'drop'),
-    
-    c('iso3c', 'year')
-  ) %>% 
-    # FIXME: filter countries/year that have no inputs into coke ovens but use
-    # coke oven outputs (which most likely are imported)
-    filter(!is.na(.data$product)) %>% 
-    assert(not_na, everything(),
-           description = 'Only valid coke oven loss data') %>%
-    group_by(!!!syms(c('iso3c', 'year'))) %>% 
-    mutate(value = (sum(-.data$value) - .data$output)
-           * .data$value / sum(.data$value),
-           flow = 'IRONSTL') %>% 
-    ungroup() %>% 
-    select('iso3c', 'year', 'product', 'flow', 'value')
-  
-  ## recalculate blast furnace inputs w/ coke oven replacements ----
-  
-  #### apply coke oven replacement ----
-  # Coke ovens and blast furnaces can be both inputs and outputs to one another at
-  # the same time.  To untangle this, we first replace blast furnace outputs that
-  # are inputs into coke ovens by coke oven outputs, which are netted with the
-  # direct outputs (above), and then replace coke oven outputs that are blast 
-  # furnace inputs by coke oven inputs (here).
-  data_BLASTFUR <- bind_rows(
-    data_BLASTFUR %>%
-      filter(!.data$product %in% outputs_COKEOVS),
-    
-    data_COKEOVS_replacement %>%
-      filter(.data$flow %in% c('EBLATFUR', 'TBLASTFUR')) %>%
-      select(-'flow')
-  ) %>% 
-    group_by(!!!syms(c('iso3c', 'year', 'product'))) %>% 
-    summarise(value = sum(.data$value), .groups = 'drop')
-  
-  ### blast furnace inputs ----
-  # inputs into transformation/energy system are negative
-  data_BLASTFUR_inputs <- data_BLASTFUR %>% 
-    filter(0 > .data$value)
-  
-  ### blast furnace replacement data ----
-  # outputs are replaced joule-by-joule with inputs, according to the input shares
-  # right_join() filters out countries/years that do not use blast furnace 
-  # products
-  data_BLASTFUR_replacement <- right_join(
-    data_BLASTFUR_inputs %>% 
-      group_by(!!!syms(c('iso3c', 'year'))) %>% 
-      mutate(factor = .data$value / sum(.data$value)) %>% 
-      ungroup() %>% 
-      select(-'value'),
-    
-    data_BLASTFUR_use %>% 
-      select(-'product'),
-    
-    c('iso3c', 'year')
-  ) %>% 
-    # FIXME: filter countries/years that have no inputs into blast furnaces, yet
-    # outputs from them and use of blast furnace products (e.g. ISR 1973)
-    filter(!is.na(.data$product)) %>% 
-    assert(not_na, everything(),
-           description = 'Only valid blast furnace replacement data') %>% 
-    mutate(value = .data$value * .data$factor) %>% 
-    group_by(!!!syms(c('iso3c', 'year', 'product', 'flow'))) %>%
-    summarise(value = sum(.data$value), .groups = 'drop')
-  
-  ## blast furnace loss data ----
-  # blast furnace losses (true losses from EBLASTFUR and transformation energy 
-  # from TBLASTFUR) are allotted to the IRONSTL sector
-  # losses are the difference of inputs and outputs, weighted by input shares
-  # right_join() filters out countries/years that do not use blast furnace 
-  # products
-  data_BLASTFUR_loss <- right_join(
-    data_BLASTFUR_inputs,
-    
-    data_BLASTFUR_outputs %>% 
-      group_by(!!!syms(c('iso3c', 'year'))) %>% 
-      summarise(output = sum(.data$value), .groups = 'drop'),
-    
-    c('iso3c', 'year')
-  ) %>% 
-    # FIXME: filter countries/years that have no inputs into blast furnaces, yet
-    # outputs from them and use of blast furnace products (e.g. ISR 1973)
-    filter(!is.na(.data$product)) %>% 
-    assert(not_na, everything(),
-           description = 'Only valid blast furnace loss data') %>% 
-    group_by(!!!syms(c('iso3c', 'year'))) %>% 
-    mutate(value = (sum(-.data$value) - .data$output) 
-           * .data$value / sum(.data$value),
-           flow = 'IRONSTL') %>%
-    ungroup() %>% 
-    select('iso3c', 'year', 'product', 'flow', 'value')
-  
-  ## replace coke oven and blast furnace products ----
-  data_replace <- bind_rows(
-    # filter already replaced data
-    data_COKEOVS_replacement %>%
-      filter(!.data$flow %in% c('EBLATFUR', 'TBLASTFUR')),
-    
-    data_BLASTFUR_replacement %>%
-      filter(!.data$flow %in% c('ECOKEOVS', 'TCOKEOVS')),
-    
-    data_COKEOVS_loss %>% 
-      sum_total_('product', name = 'TOTAL'),
-    
-    data_BLASTFUR_loss %>% 
-      sum_total_('product', name = 'TOTAL')
-  ) %>% 
-    group_by(!!!syms(setdiff(colnames(.), 'value'))) %>% 
-    summarise(value = sum(.data$value), .groups = 'drop') %>% 
-    arrange(!!!syms(c('iso3c', 'year', 'product', 'flow'))) %>% 
-    as.magpie(spatial = 1, temporal = 2, data = ncol(.))
-  
-  data_replace[is.na(data_replace)] <- 0
-  
-  regions_keep <- sort(getRegions(data))
-  years_keep   <- sort(getYears(data))
-  names_keep   <- sort(setdiff(getNames(data), 
-                               c(product_flow_COKEOVS_to_replace,
-                                 product_flow_BLASTFUR_to_replace)))
-  
-  regions_replace <- sort(getRegions(data_replace))
-  years_replace   <- sort(getYears(data_replace))
-  names_replace   <- sort(getNames(data_replace))
-  
-  data_fixed <- new.magpie(cells_and_regions = regions_keep, years = years_keep,
-                           names = unique(c(names_keep, names_replace)),
-                           fill = 0)
-  
-  data_fixed[regions_keep,years_keep,names_keep] <- data %>% 
-    `[`(regions_keep, years_keep, names_keep)
-  
-  data_fixed[regions_replace,years_replace,names_replace] <- (
-      data_fixed[regions_replace,years_replace,names_replace]
-    + data_replace[regions_replace,years_replace,names_replace]
-  )
 
-  return(data_fixed)
+  return(data)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.138.1**
+R package **mrremind**, version **0.138.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.138.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R (2022). _mrremind: MadRat REMIND Input Data Package_. R package version 0.138.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse},
   year = {2022},
-  note = {R package version 0.138.1},
+  note = {R package version 0.138.2},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Aligns aggregation of IEA data with other users (coke oven and blast furnace losses all go into the steel sector) and fixes a bug contained therein.  Increases steel FE demand, lowers other subsectors FE demand, see attached [PDF](https://github.com/pik-piam/mrremind/files/9009205/REMIND_rev_comp.pdf) for comparisons.  Global peak energy demand in `SSP2EU` does not change significantly so no changes of &alpha; factors is needed.
Additional fixes regarding IEA data holes are still coming, that should deal with low specific energy demand across sectors in various regions (e.g. `MEA` and `NEN`).
