### PR TITLE
Add buildings trajectory for new NAV_lce scenario

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29448480'
+ValidationKey: '29643750'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.152.0",
+  "version": "0.153.0",
   "description": "<p>The mrremind packages contains data preprocessing for the\n    REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.152.0
-Date: 2023-01-17
+Version: 0.153.0
+Date: 2023-01-18
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -1975,7 +1975,7 @@ calcFEdemand <- function(subtype = "FE") {
         mselect(reminditems, scenario = navigateScenarios, item = nonIndustryItems),
         addDim(mselect(reminditems, scenario = "gdp_SSP2EU", item = industryItems,
                        collapseNames = TRUE),
-               paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "all")),
+               paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "lce", "all")),
                "scenario", 3.1)
       )
     }

--- a/R/convertEDGE.R
+++ b/R/convertEDGE.R
@@ -1,11 +1,11 @@
-#' Convert IEA
+#' Convert EDGE
 #' 
 #' Convert EDGE data to data on ISO country level.
 #' 
 #' @param subtype FE for final energy or Capital for capital projections
 #' @param x MAgPIE object containing EDGE values at ISO country resolution
 #' @return EDGE data as MAgPIE object aggregated to country level
-#' @author Antoine Levesque
+#' @author Antoine Levesque, Robin Hasse
 #' 
 #' @importFrom magclass new.magpie getItems<- getNames getSets getYears mselect
 #' mbind
@@ -18,7 +18,7 @@ convertEDGE <- function(x, subtype = "FE_stationary") {
   addSSPnames <- function(x) {
     do.call("mbind", lapply(c(paste0("SSP", c(1:5, "2EU", "2_lowEn")),
                               paste0("SDP", c("", "_EI", "_RC", "_MC")),
-                              paste0("SSP2EU_NAV_", c("act", "tec", "ele", "all"))),
+                              paste0("SSP2EU_NAV_", c("act", "tec", "ele", "lce", "all"))),
       function(s) setNames(x, paste(s, getNames(x), sep = "."))
     ))
   }
@@ -89,7 +89,7 @@ convertEDGE <- function(x, subtype = "FE_stationary") {
     # duplicate SSP2 for SSP2_lowEn an SSP2EU for Navigate scenarios
     wg <- mbind(
       wg,
-      do.call("mbind", lapply(paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "all")),
+      do.call("mbind", lapply(paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "lce", "all")),
                               function(navScen) {
                                 setItems(wg[,, "gdp_SSP2EU"], 3, navScen)
                               })),
@@ -319,7 +319,7 @@ convertEDGE <- function(x, subtype = "FE_stationary") {
     # duplicate SSP2 for SSP2_lowEn an SSP2EU for Navigate scenarios
     wg <- mbind(
       wg,
-      do.call("mbind", lapply(paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "all")),
+      do.call("mbind", lapply(paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "lce", "all")),
                               function(navScen) {
                                 setItems(wg[,, "gdp_SSP2EU"], 3, navScen)
                               })),
@@ -344,7 +344,7 @@ convertEDGE <- function(x, subtype = "FE_stationary") {
     # duplicate SSP2 for SSP2_lowEn an SSP2EU for Navigate scenarios
     wp <- mbind(
       wp,
-      do.call("mbind", lapply(paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "all")),
+      do.call("mbind", lapply(paste0("gdp_SSP2EU_NAV_", c("act", "tec", "ele", "lce", "all")),
                               function(navScen) {
                                 setItems(wp[,, "gdp_SSP2EU"], 3, navScen)
                               })),

--- a/R/readEDGE.R
+++ b/R/readEDGE.R
@@ -17,7 +17,11 @@ readEDGE <- function(subtype = c("FE_stationary", "FE_buildings", "Capital", "Ca
   subtype <- match.arg(subtype)
 
   # input data version
-  ver <- "1.10"
+  ver <- "1.11"
+  scenarios <- list(
+    SSPs  = paste0("SSP", 1:5),
+    SSP2s = paste0("SSP2", c("EU", "_lowEn", paste0("_NAV_", c("act", "tec", "ele", "lce", "all")))),
+    SDPs  = paste0("SDP", c("", "_EI", "_MC", "_RC")))
 
   addDim <- function(x, addnm, dim, dimCode = 3.2) {
     do.call("mbind", lapply(addnm, function(item) {
@@ -30,15 +34,12 @@ readEDGE <- function(subtype = c("FE_stationary", "FE_buildings", "Capital", "Ca
       mstationary <- read.magpie(file.path(ver, "EDGE_TradMod.cs4r"))
       mstationary[is.na(mstationary)] <- 0
       getSets(mstationary) <- c("region", "year", "scenario", "item")
-      # duplicate: SSP2 -> SSP2EU, SSP2_lowEn and SSP1 -> SDPs
-      mstationarySPP2s <- addDim(
-        mselect(mstationary, scenario = "SSP2", collapseNames = TRUE),
-        c("SSP2EU", "SSP2_lowEn", "SSP2EU_NAV_act", "SSP2EU_NAV_tec", "SSP2EU_NAV_ele", "SSP2EU_NAV_all"),
-        "scenario", 3.1)
-      mstationarySDPs <- addDim(
-        mselect(mstationary, scenario = "SSP1", collapseNames = TRUE),
-        c("SDP", "SDP_EI", "SDP_RC", "SDP_MC"), "scenario", 3.1)
-      mstationary <- mbind(mstationary, mstationarySPP2s, mstationarySDPs)
+      mstationary <- mbind(
+        mstationary,
+        addDim(mselect(mstationary, scenario = "SSP2", collapseNames = TRUE),
+               scenarios$SSP2s, "scenario", 3.1),
+        addDim(mselect(mstationary, scenario = "SSP1", collapseNames = TRUE),
+               scenarios$SDPs, "scenario", 3.1))
       return(mstationary)
     },
     FE_buildings = {
@@ -47,6 +48,7 @@ readEDGE <- function(subtype = c("FE_stationary", "FE_buildings", "Capital", "Ca
       getNames(mbuilding) <- gsub("rcp", "", getNames(mbuilding))
       getNames(mbuilding) <- gsub("NoC", "fixed", getNames(mbuilding))
       getSets(mbuilding) <- c("region", "year", "scenario", "rcp", "item")
+      mbuilding <- mselect(mbuilding, scenario = Reduce(c, scenarios))
       return(mbuilding)
     },
     Capital = {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.152.0**
+R package **mrremind**, version **0.153.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.152.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.153.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse},
   year = {2023},
-  note = {R package version 0.152.0},
+  note = {R package version 0.153.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/man/convertEDGE.Rd
+++ b/man/convertEDGE.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convertEDGE.R
 \name{convertEDGE}
 \alias{convertEDGE}
-\title{Convert IEA}
+\title{Convert EDGE}
 \usage{
 convertEDGE(x, subtype = "FE_stationary")
 }
@@ -18,5 +18,5 @@ EDGE data as MAgPIE object aggregated to country level
 Convert EDGE data to data on ISO country level.
 }
 \author{
-Antoine Levesque
+Antoine Levesque, Robin Hasse
 }


### PR DESCRIPTION
Increment EDGE source data revision to 1.11. We now filter the scenarios with handwritten code in `readEDGE`. This allows to later add new scenarios to the data without the need to increment the revision if nothing else changed.