### PR TITLE
Update NDC Inputs to 2023

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,4 +15,4 @@ carbon_stored.*
 ^tests/.lintr$
 ^TODO\.txt$
 ^Makefile$
-
+^output$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29891400'
+ValidationKey: '30088600'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ fe_variables.csv
 *.RData
 figures
 /TODO.txt
-
+output

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.154.0",
+  "version": "0.155.0",
   "description": "<p>The mrremind packages contains data preprocessing for the\n    REMIND model.<\/p>",
   "creators": [
     {
@@ -77,6 +77,12 @@
     },
     {
       "name": "Hasse, Robin"
+    },
+    {
+      "name": "Fuchs, Sophie"
+    },
+    {
+      "name": "Mandaroux, Rahel"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.154.0
-Date: 2023-02-22
+Version: 0.155.0
+Date: 2023-02-24
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,9 @@ Authors@R: c(
     person("Falk", "Benke", role = "aut"),
     person("Pascal", "Weigmann", role = "aut"),
     person("Oliver", "Richters", role = "aut"),
-    person("Robin", "Hasse", role = "aut")
+    person("Robin", "Hasse", role = "aut"),
+    person("Sophie", "Fuchs", role = "aut"),
+    person("Rahel", "Mandaroux", role = "aut")
   )
 Description: The mrremind packages contains data preprocessing for the
     REMIND model.

--- a/R/calcCapTarget.R
+++ b/R/calcCapTarget.R
@@ -28,7 +28,9 @@ calcCapTarget <- function(sources) {
       "2021_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2021_cond"),
       "2021_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2021_uncond"),
       "2022_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2022_cond"),
-      "2022_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2022_uncond")
+      "2022_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2022_uncond"),
+      "2023_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2023_cond"),
+      "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2023_uncond")
     )
 
     listYears   <- lapply(listCapacitiesNDC, getItems, dim = "year") %>% unlist() %>% unique() %>% sort()

--- a/R/calcEmiTarget.R
+++ b/R/calcEmiTarget.R
@@ -13,6 +13,7 @@ calcEmiTarget <- function(sources, subtype) {
   gwpCH4 <- 28 # "Global Warming Potentials of CH4, AR5 WG1 CH08 Table 8.7"     /28/
   gwpN2O <- 265 # "Global Warming Potentials of N2O, AR5 WG1 CH08 Table 8.7"     /265/
   # calculate GHG total of CO2, CH4 and N2O [unit Mt CO2eq]
+  # note: CEDS2021 does not include 'Emi|N2O|Land Use|*' variables and cannot be used.
   ghg <- ceds[, seq(1990, 2015, 1), c("Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)")] +
     +gwpN2O / 1000 * dimSums(ceds[, seq(1990, 2015, 1), c("Emi|N2O|Energy and Industrial Processes (kt N2O/yr)",
                                                   "Emi|N2O|Land Use|Agriculture and Biomass Burning (kt N2O/yr)",
@@ -44,7 +45,9 @@ calcEmiTarget <- function(sources, subtype) {
       "2021_cond"   = readSource("UNFCCC_NDC", subtype = "Emissions_2021_cond"),
       "2021_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2021_uncond"),
       "2022_cond"   = readSource("UNFCCC_NDC", subtype = "Emissions_2022_cond"),
-      "2022_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2022_uncond")
+      "2022_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2022_uncond"),
+      "2023_cond"   = readSource("UNFCCC_NDC", subtype = "Emissions_2023_cond"),
+      "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2023_uncond")
     )
 
     listYears   <- lapply(listGhgfactors, getItems, dim = "year") %>% unlist() %>% unique() %>% sort()
@@ -71,7 +74,8 @@ calcEmiTarget <- function(sources, subtype) {
       # check share of total emissions by countries with quantitative target
       dimSums(ghgTarget, dim = c(1)) / setYears(setNames(globGhg[, 2005, ], NULL), NULL)
       description <- "Multiplier for target year emissions vs 2005 emissions, as weighted average for all countries with NDC target in each region per target year"
-      return(list(x = convertNAto0(ghgfactor), weight = ghgTarget[, , ], unit = "1", description = description))
+      return(list(x = convertNAto0(ghgfactor), weight = ghgTarget[, , ], unit = "1", description = description,
+                  min = -5, max = 4)) # these are not necessary fixed values defined until eternity, but rather plausibility checks
 
     } else if (grepl("Ghgshare2005", subtype, fixed = TRUE)) { # p45_2005share_target.cs3r
       # calculate growth for GDP weight for GHG emission share
@@ -81,14 +85,14 @@ calcEmiTarget <- function(sources, subtype) {
         gdpWeight[, t, ] <- setYears(ghg[, 2005, ] / gdp[, 2005, ], NULL) * gdp[, t, ]
       }
       description <- "2005 GHG emission share of countries with quantifyable emissions under NDC in particular region per target year"
-      return(list(x = 1 * (!is.na(ghgfactor[, , ])), weight = gdpWeight, unit = "1", description = description))
+      return(list(x = 1 * (!is.na(ghgfactor[, , ])), weight = gdpWeight, unit = "1", description = description, min = 0, max = 1))
 
     } else if (grepl("Ghghistshare", subtype, fixed = TRUE)) {
       # make ghgTarget only represent countries with 2030 data
       dummy2 <- new.magpie(cells_and_regions = listRegions, years = getItems(ghg, dim = "year"), names = names(listGhgfactors))
       dummy2[, , ] <- dummy1[, "y2030", ]
       description <- "GHG emissions share of countries with quantifyable 2030 target in particular region"
-      return(list(x = dummy2, weight = ghg, unit = "1", description = description))
+      return(list(x = dummy2, weight = ghg, unit = "1", description = description, min = 0, max = 1))
 
     } else {
       cat("Unknown subtype ", subtype, " for calcEmiTarget with source UNFCCC_NDC. Nothing returned.")

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -3,8 +3,9 @@
 #' data on different policy targets (capacity, emission, and share targets) with different variations
 #' @details Country name is ISO coded. Capacity/Additional Capacity targets are in GW. Generation/Production targets are in GWh.
 #' @return  magpie object
-#' @author  Aman Malik, Christoph Bertram, Oliver Richters
-#' @param subtype Capacity_2022_cond (or 2018/2021 or uncond) for capacity target, Emissions_2022_cond (or 2018/2021 or uncond) for Emissions targets
+#' @author  Aman Malik, Christoph Bertram, Oliver Richters, Sophie Fuchs, Rahel Mandaroux
+#' @param subtype Capacity_2023_cond (or 2018/2021/2022 or uncond) for capacity target,
+#' Emissions_2023_cond (or 2018/2021/2022 or uncond) for Emissions targets
 #' @importFrom readxl read_xlsx
 #' @importFrom dplyr select
 #' @importFrom gdata duplicated2
@@ -15,10 +16,12 @@ readUNFCCC_NDC <- function(subtype) {
     NDCfile <- "NDC_2018.xlsx"
   } else if (grepl("2021", subtype, fixed = TRUE)) {
     NDCfile <- "NDC_2021.xlsx"
+  } else if (grepl("2022", subtype, fixed = TRUE)) {
+    NDCfile <- "NDC_2022-12-31.xlsx"
   } else {
-    NDCfile <- "NDC_2022.xlsx"
-    if (!grepl("2022", subtype, fixed = TRUE)) {
-      cat("\nNo data for year in ", subtype, " available. Choose default: ", NDCfile)
+    NDCfile <- "NDC_2023-02-24.xlsx"
+    if (!grepl("2023", subtype, fixed = TRUE)) {
+      warning("\nNo data for year in ", subtype, " available. Choose default: ", NDCfile)
     }
   }
 
@@ -29,22 +32,43 @@ readUNFCCC_NDC <- function(subtype) {
                         "numeric", "numeric", "numeric", "numeric", "skip", "skip", "skip"))
     x <- as.magpie(NDC, spatial = 1, temporal = 2, datacol = 3)
   }
-
   if (grepl("Emissions", subtype, fixed = TRUE)) {
     input <- read_xlsx(NDCfile, sheet = "Emissions", skip = 3, na = c("?", ""))
     # select the relevant columns to work upon
     input2 <- select(input, 2, 7:14)
     # rename columns
-    colnames(input2) <- c("ISO_Code", "Reference_Year", "BAU_or_Reference_emissions_in_MtCO2e", "Target_Year", "Type", "Unconditional", "Conditional", "Uncond2", "Cond2")
+    colnames(input2) <- c("ISO_Code", "Reference_Year", "BAU_or_Reference_emissions_in_MtCO2e", "Target_Year",
+                          "Type", "Unconditional", "Conditional", "Uncond2", "Cond2")
     # if no entry in first two quantitative columns, use data from 3rd and 4th
-    input2[is.na(input2$Unconditional), ]$Unconditional <- input2[is.na(input2$Unconditional), ]$Uncond2
-    input2[is.na(input2$Conditional), ]$Conditional <- input2[is.na(input2$Conditional), ]$Cond2
+    bothcolumns <- input2$ISO_Code[(! is.na(input2$Unconditional) & ! is.na(input2$Uncond2)) |
+                                   (! is.na(input2$Conditional) & ! is.na(input2$Cond2))]
+    if (length(bothcolumns) > 0) {
+        warning("readUNFCCC_NDC with subtype=", subtype, " has values in more than one Uncond/Cond column in: ",
+                paste(bothcolumns, collapse = ", "))
+    }
     # check consistency of Type. Note: this has to be identical to the definition in calcEmiTarget.R
     allowedType <- c("GHG-Absolute", "GHG", "GHG/GDP", "CO2/GDP", "GHG-fixed-total", "GHG/CAP")
     if (FALSE %in% (input2$Type %in% allowedType)) {
-      cat("Unknown data type used in ", NDCfile, ": ", paste(unique(input2$Type)[!unique(input2$Type) %in% allowedType], collapse = ", "), ". Please use: ", paste(allowedType, collapse = " or "), ".")
+      warning("Unknown data type used in ", NDCfile, ": ",
+              paste(unique(input2$Type)[!unique(input2$Type) %in% allowedType], collapse = ", "),
+              ". Please use: ", paste(allowedType, collapse = " or "), ".")
     }
+    # check that correct columns are used for relative and Mt stuff
+    if (! grepl("Emissions_20(18|21)", subtype)) {
+        colRelative <- is.na(input2$Uncond2) & is.na(input2$Cond2) &
+                       input2$Type %in% c("GHG", "GHG/GDP", "CO2/GDP", "GHG/CAP")
+        colAbsolute <- is.na(input2$Unconditional) & is.na(input2$Conditional) &
+                       input2$Type %in% c("GHG-Absolute", "GHG-fixed-total")
+        colInconsistent <- ! (colRelative | colAbsolute)
+        if (any(colInconsistent)) {
+            warning("readUNFCCC_NDC with subtype=", subtype, " noticed that the target column used does not ",
+                    "correspond to the type used for: ", paste(input2$ISO_Code[colInconsistent], collapse = ", "))
+        }
+    }
+
     # drop extra columns
+    input2[is.na(input2$Unconditional), ]$Unconditional <- input2[is.na(input2$Unconditional), ]$Uncond2
+    input2[is.na(input2$Conditional), ]$Conditional <- input2[is.na(input2$Conditional), ]$Cond2
     input2$Uncond2 <- NULL
     input2$Cond2 <- NULL
 
@@ -53,8 +77,17 @@ readUNFCCC_NDC <- function(subtype) {
 
     # in case a country has two or more types of targets for same year, use GHG-Absolute targets
     # note: the only remaining country in 2021 is MGD Madagascar based on its 2016 submission
-    input2 <- input2[!(input2$ISO_Code %in% input2[duplicated(input2[c(1, 4)]), ]$ISO_Code & input2$Target_Year %in% input2[duplicated(input2[c(1, 4)]), ]$Target_Year & input2$Type != "GHG-Absolute"), ]
+    input2 <- input2[!(input2$ISO_Code %in% input2[duplicated(input2[c(1, 4)]), ]$ISO_Code
+                     & input2$Target_Year %in% input2[duplicated(input2[c(1, 4)]), ]$Target_Year
+                     & input2$Type != "GHG-Absolute"), ]
 
+    # warning if emission changes have no reference year or BAU reference
+    ref4change <- input2$ISO_Code[input2$Reference_Year %in% c("no", NA) &
+                                  input2$Type %in% c("GHG", "CO2/GDP", "GHG/GDP", "GHG-Absolute")]
+    if (length(ref4change) > 0) {
+      warning("readUNFCCC_NDC with subtype=", subtype, " has no entry in column reference year in:",
+              paste(ref4change, collapse = ", "))
+    }
     # as magclass can only cover numerical values well, transform: in column 2 BAU into -1, and Type into number based on allowedType
     input2[2] <- as.numeric(unlist(rapply(input2[2], function(x) ifelse(x == "BAU", -1, ifelse(x == "no", -2, x)), how = "replace")))
     input2[5] <- as.numeric(unlist(rapply(input2[5], function(x) match(x, allowedType), how = "replace")))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.154.0**
+R package **mrremind**, version **0.155.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,16 +39,16 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.154.0, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.155.0, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {mrremind: MadRat REMIND Input Data Package},
-  author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse},
+  author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.154.0},
+  note = {R package version 0.155.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/man/convertUNFCCC_NDC.Rd
+++ b/man/convertUNFCCC_NDC.Rd
@@ -9,7 +9,8 @@ convertUNFCCC_NDC(x, subtype)
 \arguments{
 \item{x}{MAgPIE object to be converted}
 
-\item{subtype}{Capacity_YYYY_cond or Capacity_YYYY_uncond for Capacity Targets, Emissions_YYYY_cond or Emissions_YYYY_uncond for Emissions targets, with YYYY NDC version year}
+\item{subtype}{Capacity_YYYY_cond or Capacity_YYYY_uncond for Capacity Targets, Emissions_YYYY_cond or
+Emissions_YYYY_uncond for Emissions targets, with YYYY NDC version year}
 }
 \value{
 Magpie object with Total Installed Capacity (GW) targets, target years differ depending upon the database.

--- a/man/mrremind-package.Rd
+++ b/man/mrremind-package.Rd
@@ -44,6 +44,8 @@ Authors:
   \item Pascal Weigmann
   \item Oliver Richters
   \item Robin Hasse
+  \item Sophie Fuchs
+  \item Rahel Mandaroux
 }
 
 }

--- a/man/readUNFCCC_NDC.Rd
+++ b/man/readUNFCCC_NDC.Rd
@@ -7,7 +7,8 @@
 readUNFCCC_NDC(subtype)
 }
 \arguments{
-\item{subtype}{Capacity_2022_cond (or 2018/2021 or uncond) for capacity target, Emissions_2022_cond (or 2018/2021 or uncond) for Emissions targets}
+\item{subtype}{Capacity_2023_cond (or 2018/2021/2022 or uncond) for capacity target,
+Emissions_2023_cond (or 2018/2021/2022 or uncond) for Emissions targets}
 }
 \value{
 magpie object
@@ -20,5 +21,5 @@ data on different policy targets (capacity, emission, and share targets) with di
 Country name is ISO coded. Capacity/Additional Capacity targets are in GW. Generation/Production targets are in GWh.
 }
 \author{
-Aman Malik, Christoph Bertram, Oliver Richters
+Aman Malik, Christoph Bertram, Oliver Richters, Sophie Fuchs, Rahel Mandaroux
 }


### PR DESCRIPTION
- Update 2022 NDC input data with submissions until December 31, 2022.
- New 2023 input data with submissions until February 24, 2023
- Great Britain is not in EUR target as of 2022
- Added consistency checks in readUNFCCC_NDC.R
