### PR TITLE
consistency check in readUNFCCC_NDC.R (cond. NDC target more stringent than uncond.)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30088600'
+ValidationKey: '30115767'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.155.0",
+  "version": "0.155.1",
   "description": "<p>The mrremind packages contains data preprocessing for the\n    REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.155.0
-Date: 2023-02-24
+Version: 0.155.1
+Date: 2023-03-01
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -96,7 +96,8 @@ readUNFCCC_NDC <- function(subtype) {
               paste(ref4change, collapse = ", "))
     }
     # as magclass can only cover numerical values well, transform: in column 2 BAU into -1, and Type into number based on allowedType
-    input2[2] <- as.numeric(unlist(rapply(input2[2], function(x) ifelse(x == "BAU", -1, ifelse(x == "no", -2, x)), how = "replace")))
+    input2[2] <- as.numeric(unlist(rapply(input2[2], function(x) 
+                            ifelse(x == "BAU", -1, ifelse(x == "no", -2, x)), how = "replace")))
     input2[5] <- as.numeric(unlist(rapply(input2[5], function(x) match(x, allowedType), how = "replace")))
     # sort with c(1,4,2,3,5,6,7) to get region into first and years into second column
     x <- as.magpie(input2[c(1, 4, 2, 3, 5, 6, 7)], spatial = 1, temporal = 2, datacol = 3)

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -81,6 +81,13 @@ readUNFCCC_NDC <- function(subtype) {
                      & input2$Target_Year %in% input2[duplicated(input2[c(1, 4)]), ]$Target_Year
                      & input2$Type != "GHG-Absolute"), ]
 
+    # check whether conditional is more stringent than unconditional
+    condTrumpsUncond <- (input2$Conditional <= input2$Unconditional) | is.na(input2$Unconditional)
+    if (any(! condTrumpsUncond)) {
+      warning("readUNFCCC_NDC with subtype=", subtype, ": unconditional target more stringent than conditional in: ",
+              paste(input2$ISO_Code[! condTrumpsUncond], collapse = ", "))
+    }
+
     # warning if emission changes have no reference year or BAU reference
     ref4change <- input2$ISO_Code[input2$Reference_Year %in% c("no", NA) &
                                   input2$Type %in% c("GHG", "CO2/GDP", "GHG/GDP", "GHG-Absolute")]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.155.0**
+R package **mrremind**, version **0.155.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.155.0, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.155.1, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.155.0},
+  note = {R package version 0.155.1},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
- Added consistency check in readUNFCCC_NDC.R
- Show function "input2[2]" (readUNFCCC_NDC.R, l.92) split over two lines to avoid linter warning (120 characters)