### PR TITLE
remove camelCase linter rule from this package

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
-linters: lucode2::lintrRules()
+linters: lucode2::lintrRules(modification = list(object_name_linter = NULL))
 encoding: "UTF-8"

--- a/tests/.lintr
+++ b/tests/.lintr
@@ -1,2 +1,2 @@
-linters: lucode2::lintrRules(allowUndesirable = TRUE)
+linters: lucode2::lintrRules(allowUndesirable = TRUE, modification = list(object_name_linter = NULL))
 encoding: "UTF-8"


### PR DESCRIPTION
Looks like lucode2 allows for per-package overwriting of the universal lucode linter rules by overwriting the lint.R files in the repo. 

@pfuehrlich-pik FYI, we want to disable this linter rule for REMIND packages only. Let me know if there is a better way to do it. 

@LaviniaBaumstark @mikapfl Thoughts on this approach? 


Btw, another variation would be
`lucode2::lintrRules(modification = list(object_name_linter(styles = c("camelCase", "snake_case"))))`

This accepts camel and snake case, but would complain for example here: `REMIND_variable`
