### PR TITLE
Have industry track historic FE demand including 2020

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30890160'
+ValidationKey: '30917550'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.158.9",
+  "version": "0.159.0",
   "description": "<p>The mrremind packages contains data preprocessing for the\n    REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.158.9
-Date: 2023-03-24
+Version: 0.159.0
+Date: 2023-03-29
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -1533,7 +1533,7 @@ calcFEdemand <- function(subtype = "FE") {
 
         c('scenario', 'year', 'region', 'pf', 'subsector')
       ) %>%
-        mutate(foo = pmin(1, pmax(0, (.data$year - 2020) / (2100 - 2020))),
+        mutate(foo = pmin(1, pmax(0, (.data$year - 2015) / (2100 - 2015))),
                share = .data$share.hist * (1 - .data$foo)
                + .data$share.future * .data$foo,
                subsector = ifelse('steel' == .data$subsector,

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -406,8 +406,8 @@ calcFEdemand <- function(subtype = "FE") {
                                       name = 'regionmappingH12.csv') %>%
         select(country = 'X', iso3c = 'CountryCode', region = 'RegionCode')
 
-      historic_trend <- c(2004, 2015)
-      phasein_period <- c(2015, 2050)
+      historic_trend <- c(2004, 2020)
+      phasein_period <- c(2020, 2050)   # FIXME: extend to 2055 to keep 35 yrs?
       phasein_time   <- phasein_period[2] - phasein_period[1]
 
       dataInd <- bind_rows(
@@ -1175,7 +1175,7 @@ calcFEdemand <- function(subtype = "FE") {
         as.magpie(spatial = 1, temporal = 2, data = ncol(.))
 
       ## subsector FE shares ----
-      ### get 1993-2015 industry FE ----
+      ### get 1993-2020 industry FE ----
       industry_subsectors_en <- calcOutput(
         type = 'IO', subtype = 'output_Industry_subsectors',
         aggregate = FALSE
@@ -1187,9 +1187,9 @@ calcFEdemand <- function(subtype = "FE") {
                value = 'Value') %>%
         quitte::character.data.frame() %>%
         mutate(year = as.integer(as.character(.data$year))) %>%
-        # get 1993-2015 industry FE data
+        # get 1993-2020 industry FE data
         filter(grepl('^fe.*_(cement|chemicals|steel|otherInd)', .data$pf),
-               dplyr::between(.data$year, 1993, 2015)) %>%
+               dplyr::between(.data$year, 1993, 2020)) %>%
         # sum up fossil and bio SE (which produce the same FE), aggregate
         # regions
         full_join(region_mapping_21, 'iso3c') %>%
@@ -1533,7 +1533,7 @@ calcFEdemand <- function(subtype = "FE") {
 
         c('scenario', 'year', 'region', 'pf', 'subsector')
       ) %>%
-        mutate(foo = pmin(1, pmax(0, (.data$year - 2015) / (2100 - 2015))),
+        mutate(foo = pmin(1, pmax(0, (.data$year - 2020) / (2100 - 2020))),
                share = .data$share.hist * (1 - .data$foo)
                + .data$share.future * .data$foo,
                subsector = ifelse('steel' == .data$subsector,
@@ -1738,7 +1738,7 @@ calcFEdemand <- function(subtype = "FE") {
 
           'subsector'
         ) %>%
-        filter(2015 < .data$year,
+        filter(2020 < .data$year,
                !is.na(.data$limit),
                .data$specific.energy < .data$limit) %>%
         select('scenario', 'region', 'subsector', 'year')
@@ -1794,12 +1794,12 @@ calcFEdemand <- function(subtype = "FE") {
           specific.energy = ifelse(
             'absolute' == .data$type,
             ( (.data$specific.energy - .data$limit)
-              * pmin(1, (1 - .data$alpha) ^ (.data$year - 2015))
+              * pmin(1, (1 - .data$alpha) ^ (.data$year - 2020))
             )
             + .data$limit,
 
             ( .data$specific.energy * (1 - .data$limit)
-              * pmin(1, (1 - .data$alpha) ^ (.data$year - 2015))
+              * pmin(1, (1 - .data$alpha) ^ (.data$year - 2020))
             )
             + (.data$specific.energy * .data$limit))) %>%
         ungroup() %>%
@@ -1838,8 +1838,8 @@ calcFEdemand <- function(subtype = "FE") {
         c('scenario', 'year', 'subsector', 'pf')
       ) %>%
         mutate(
-          # converge from 2015 to 2100
-          foo = pmin(1, pmax(0, (.data$year - 2015) / (2100 - 2015))),
+          # converge from 2020 to 2100
+          foo = pmin(1, pmax(0, (.data$year - 2020) / (2100 - 2020))),
           share = (1 - .data$foo) * .data$share
           # use minimum of regional and global share, so regions doing
           # better than the average don't regress

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.158.9**
+R package **mrremind**, version **0.159.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.158.9, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.159.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.158.9},
+  note = {R package version 0.159.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Sometimes you just try something to see where it falls apart, and then it just works …

Updated industry electricity demand (tracks historic data to 2020 instead of 2015)
![feel](https://user-images.githubusercontent.com/53254462/227185300-bfc75cec-0b89-4242-adab-9d710c31974c.png)