### PR TITLE
fix calculation of steel production estimates; was broken in b9143ba

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30789792'
+ValidationKey: '30812400'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrremind: MadRat REMIND Input Data Package",
-  "version": "0.158.4",
+  "version": "0.158.5",
   "description": "<p>The mrremind packages contains data preprocessing for the\n    REMIND model.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.158.4
-Date: 2023-03-22
+Version: 0.158.5
+Date: 2023-03-24
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/EDGE-Industry.R
+++ b/R/EDGE-Industry.R
@@ -890,10 +890,15 @@ calcSteel_Projections <- function(subtype = 'production',
       complete(nesting(!!sym('scenario')),
                iso3c = unique(production_estimates$iso3c),
                year = unique(production_estimates$year)) %>%
-      mutate(value = case_when(
-        max(steel_historic_prod$year) >= .data$year ~ 1,
-        is.na(.data$value) ~ last(na.omit(.data$value)),
-        TRUE ~ .data$value)) %>%
+      group_by(.data$scenario, .data$iso3c) %>%
+      mutate(
+        value = case_when(
+          max(steel_historic_prod$year) >= .data$year ~ 1,
+          TRUE ~ .data$value),
+        value = case_when(
+          is.na(.data$value) ~ last(na.omit(.data$value)),
+          TRUE ~ .data$value)) %>%
+      ungroup() %>%
       left_join(production_estimates, c('scenario', 'iso3c', 'year')) %>%
       mutate(production = .data$production * .data$value) %>%
       select(-'value')

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.158.4**
+R package **mrremind**, version **0.158.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.158.4, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.158.5, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.158.4},
+  note = {R package version 0.158.5},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
```
$ tar -Oxf /p/projects/rd3mod/inputdata/output/rev6.439-check-0.158.5.9001_62eff8f7_remind.tgz ./f_fedemand.cs4r | grep "20[1-2].,NEU,gdp_SSP2EU,feso_steel"
2010,NEU,gdp_SSP2EU,feso_steel,0.19622695
2015,NEU,gdp_SSP2EU,feso_steel,0.20186566
2020,NEU,gdp_SSP2EU,feso_steel,0.17863955
2025,NEU,gdp_SSP2EU,feso_steel,0.12257134
```
New input data avaliable as `rev6.439-check-0.158.5.9001`.