### PR TITLE
hotfix: discard ODYM_RECC, go back to original SDP_XX Industry Demands

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '30967584'
+ValidationKey: '30988629'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.159.2
-date-released: '2023-04-05'
+version: 0.159.3
+date-released: '2023-04-06'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.159.2
-Date: 2023-04-05
+Version: 0.159.3
+Date: 2023-04-06
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -897,8 +897,9 @@ calcFEdemand <- function(subtype = "FE") {
         select(scenario = 'Data1', base.scenario = 'Data2', region = 'Data3',
                subsector = 'Data4', name = 'Data5', value = 'Value') %>%
         quitte::character.data.frame() %>%
-        filter(!.data$scenario %in% c('gdp_SDP_EI', 'gdp_SDP_MC',
-                                      'gdp_SDP_RC')) %>%   # FIXME
+        # FIXME hotfix to go back to original SDP_XX implementation (BS 2023-04-06)
+        # filter(!.data$scenario %in% c('gdp_SDP_EI', 'gdp_SDP_MC',
+                                      # 'gdp_SDP_RC')) %>%   # FIXME
         pivot_wider() %>%
         mutate(subsector = paste0('ue_', .data$subsector))
 
@@ -1169,8 +1170,9 @@ calcFEdemand <- function(subtype = "FE") {
           mutate(value = .data$value * .data$population * .data$activity) %>%
           select('iso3c', 'scenario', 'subsector', 'year', 'value')
       )
-
-      industry_subsectors_ue <- foo4 %>%
+      # FIXME hotkfix to go back to original SDP_XX implementation (BS 2023-04-06)
+      # industry_subsectors_ue <- foo4 %>%
+      industry_subsectors_ue <- foo3 %>%
         select('iso3c', 'year', 'scenario', pf = 'subsector', 'value') %>%
         as.magpie(spatial = 1, temporal = 2, data = ncol(.))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.159.2**
+R package **mrremind**, version **0.159.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.159.2, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.159.3, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.159.2},
+  note = {R package version 0.159.3},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Go back to original (our own approach) of calculating SDP_XX FE Industry pathways, instead of using trends from ODYM_RECC (which lead to weird values). Code changes following instructions by @0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q . Cleanup to follow in later commit.