### PR TITLE
update historic CHA gas capacity values 2010-2020

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31192777'
+ValidationKey: '31213840'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.160.3
-date-released: '2023-04-12'
+version: 0.160.4
+date-released: '2023-04-13'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.160.3
-Date: 2023-04-12
+Version: 0.160.4
+Date: 2023-04-13
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCapacity.R
+++ b/R/calcCapacity.R
@@ -94,21 +94,21 @@ calcCapacity <- function(subtype) {
     #    ***CG: fix CHA gas power capacities: 97 GW by September 2020 (Oxford Institute for Energy Studies:
     #    Natural gas in China’s power sector: Challenges and the road ahead
     #    (https://www.oxfordenergy.org/wpcms/wp-content/uploads/2020/12/Insight-80-Natural-gas-in-Chinas-power-sector.pdf)
-    #    >60% gas plants are co-generation, rest are peaking
-    #    *** for 2018-2022, take 90GW, 90GW*0.6=54, the rest is split between ngcc and ngt
+    #    ~50% is peaking (= ngt), the other 50 is called cogeneration but contains ngcc and gaschp
+    #    *** for 2018-2022, take 90GW, 90GW*0.5=50GW ngt, the rest is split between ngcc and gaschp 70:30 (from IEA EB energy output)
 
     CHA.2020.GasData <- as.magpie(
       tribble(
         ~region,   ~year,   ~data,      ~value,
-        "CHN",     2010,    "gaschp",   0.022,
-        "CHN",     2015,    "gaschp",   0.05,
-        "CHN",     2020,    "gaschp",   0.054,
-        "CHN",     2010,    "ngcc",     0.001,
-        "CHN",     2015,    "ngcc",     0.005,
-        "CHN",     2020,    "ngcc",     0.01,
-        "CHN",     2010,    "ngt",      0.003,
-        "CHN",     2015,    "ngt",      0.016,
-        "CHN",     2020,    "ngt",      0.026))
+        "CHN",     2010,    "gaschp",   0.004,
+        "CHN",     2015,    "gaschp",   0.011,
+        "CHN",     2020,    "gaschp",   0.014,
+        "CHN",     2010,    "ngcc",     0.009,
+        "CHN",     2015,    "ngcc",     0.025,
+        "CHN",     2020,    "ngcc",     0.032,
+        "CHN",     2010,    "ngt",      0.013,
+        "CHN",     2015,    "ngt",      0.036,
+        "CHN",     2020,    "ngt",      0.045))
 
     # RP: add upper bound for USA PV in 2025, as current forecast by Wood Mackenzie Solar Market Insight Report 2022 sees ~ 265 GW DC in 2025 in
     # bullish scenario. So it would be less in GW_AC, but REMIND corrects for lower model CF than real world (in USA) by upscaling capacity

--- a/man/calcFEdemand.Rd
+++ b/man/calcFEdemand.Rd
@@ -4,10 +4,15 @@
 \alias{calcFEdemand}
 \title{Edge data with its original sectoral division}
 \usage{
-calcFEdemand(subtype = "FE")
+calcFEdemand(subtype = "FE", use_ODYM_RECC = FALSE)
 }
 \arguments{
-\item{subtype}{Final energy (FE) or Energy service (ES) or Useful/Final Energy items from EDGEv3 corresponding to REMIND FE items (UE_for_Eff,FE_for_Eff)}
+\item{subtype}{Final energy (FE) or Energy service (ES) or Useful/Final
+Energy items from EDGEv3 corresponding to REMIND FE items (UE_for_Eff,
+FE_for_Eff)}
+
+\item{use_ODYM_RECC}{per-capita pathways for `SDP_xx` scenarios?  (Defaults
+to `FALSE`.)}
 }
 \description{
 Returns the Edge data at the Remind level


### PR DESCRIPTION
shift from gaschp to ngcc/ngt based on the IEA energy balances values on CHP electricity production vs non-CHP electricity production
