### PR TITLE
update NDC targets to 2023-05-31

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31890778'
+ValidationKey: '31916835'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9007
+    rev: v0.3.2.9013
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.163.4
-date-released: '2023-06-09'
+version: 0.163.5
+date-released: '2023-06-13'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.163.4
-Date: 2023-06-09
+Version: 0.163.5
+Date: 2023-06-13
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary().
-	Rscript -e 'lucode2::buildLibrary()'
+build:          ## Build the package using lucode2::buildLibrary(). You can pass the
+                ## updateType with 'make build u=3'
+	Rscript -e 'lucode2::buildLibrary(updateType = "$(u)")'
 
 check:          ## Build documentation and vignettes, run testthat tests,
                 ## and check if code etiquette is followed using lucode2::check().

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -18,7 +18,7 @@ readUNFCCC_NDC <- function(subtype) {
   } else if (grepl("2022", subtype, fixed = TRUE)) {
     NDCfile <- "NDC_2022-12-31.xlsx"
   } else {
-    NDCfile <- "NDC_2023-02-24.xlsx"
+    NDCfile <- "NDC_2023-05-31.xlsx"
     if (!grepl("2023", subtype, fixed = TRUE)) {
       warning("\nNo data for year in ", subtype, " available. Choose default: ", NDCfile)
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.163.4**
+R package **mrremind**, version **0.163.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.163.4, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.163.5, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.163.4},
+  note = {R package version 0.163.5},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Updated NDCs for Holy See / Vatican, Kiribati and Turkey.

Has a strange effect: Turkey strengthens its 2030 NDC target from -21% to -42%, but from a incredibly high BAU scenario (roughly four times their 2020 emissions). So high the NDC target was until now [dropped by our script](https://github.com/pik-piam/mrremind/blob/master/R/convertUNFCCC_NDC.R#L345-L347) as unrealistic. Now, it is below the threshold and actually has an impact: The strengthened target basically leads to 0 carbon taxes because the NDC target is overachieved anyway. Stupid. What should we do?

Kiribati leads to massively increased coverage in `OAS:` before just `43.90 %` of 2005 emissions had a NDC target, now it jumps to `44.02 %`.

![image](https://github.com/pik-piam/mrremind/assets/90761609/60ca6d25-0734-4e65-9020-c36e73bc1ced)
