### PR TITLE
add 2020 CO2 prices to calcCO2Prices.R

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31916835'
+ValidationKey: '32027560'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.163.5
-date-released: '2023-06-13'
+version: 0.164.0
+date-released: '2023-06-21'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.163.5
-Date: 2023-06-13
+Version: 0.164.0
+Date: 2023-06-21
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCO2Prices.R
+++ b/R/calcCO2Prices.R
@@ -1,17 +1,27 @@
-
-
-
 calcCO2Prices <- function() {
-  
+
   # read data
-  x <- readSource("ExpertGuess",subtype="co2prices")
+  x <- readSource("ExpertGuess", subtype = "co2prices")
   getNames(x) <- NULL
-  
+
   # read data used for weight
-  ceds <- calcOutput("Emissions",datasource="CEDS2REMIND",aggregate = FALSE)[,getYears(x),"Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)"]
-  
+  ceds <- calcOutput("Emissions", datasource = "CEDS2021", aggregate = FALSE)
+  ceds <- ceds[, , "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)"]
+
+  # if most recent year is not in ceds, use latest ceds year that is available
+  cedsyears <- getYears(ceds, as.integer = TRUE)
+  xyears <- getYears(x, as.integer = TRUE)
+  cedsmissing <- setdiff(xyears, cedsyears)
+  if (length(cedsmissing) == 1 && cedsmissing > max(cedsyears)) {
+    cedsyears <- c(intersect(cedsyears, xyears), max(cedsyears))
+    ceds <- ceds[, cedsyears, ]
+    getYears(ceds) <- xyears
+  } else if (length(cedsmissing) > 1) {
+    stop("CEDS data not available for ", paste(cedsmissing, collapse = ", "))
+  }
+
   return(list(x           = x,
               weight      = ceds,
               unit        = "US$2005/t CO2",
-              description = "CO2 prices in 2010 and 2015"))
+              description = "CO2 prices in 2010, 2015 and 2020"))
 }

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -37,7 +37,7 @@ readExpertGuess <- function(subtype) {
   } else if (subtype == "CCSbounds") {
     a <- read.csv("CCSbounds.csv", sep = ";")
   } else if (subtype == "co2prices") {
-    a <- read.csv("co2prices.csv", sep = ";")
+    a <- read.csv("co2prices-2023-06.csv", sep = ";")
   } else if (subtype == "costsTradePeFinancial") {
     a <- read.csv("pm_costsTradePeFinancial.csv",
                   sep = ";",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.163.5**
+R package **mrremind**, version **0.164.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.163.5, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.164.0, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.163.5},
+  note = {R package version 0.164.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
- csv update file was prepared by @sophiefuchs 
- for the weighting, replace CEDS2REMIND by CEDS2021 which goes at least to 2019. For 2020, use 2019 value
- Results for H12:
```
           variable
CountryCode y2010 y2015 y2020
        LAM   0.0     0  10.0
        OAS   0.0     0   5.0
        SSA   0.0     0   1.0
        EUR  10.0    10  25.0
        NEU   2.5     5  10.0
        MEA   0.0     0   2.5
        REF   0.0     0   2.5
        CAZ   0.0     0  20.0
        CHA   0.0     0   5.0
        IND   0.0     0   1.0
        JPN   0.0     0  15.0
        USA   0.0     0  20.0
```