### PR TITLE
Average buildings FE paths to 5-yr time steps

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '32675220'
+ValidationKey: '32694786'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.167.0
+version: 0.167.1
 date-released: '2023-07-28'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.167.0
+Version: 0.167.1
 Date: 2023-07-28
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -13,7 +13,8 @@
 #' @importFrom dplyr anti_join arrange as_tibble between bind_rows case_when
 #'   distinct filter first full_join group_by inner_join lag last left_join
 #'   matches mutate n rename right_join select semi_join summarise ungroup
-#' @importFrom magclass mselect getItems getItems<-
+#' @importFrom magclass mselect getItems getItems<- time_interpolate
+#' @importFrom madrat toolAggregate
 #' @importFrom magrittr %>% %<>%
 #' @importFrom quitte as.quitte cartesian character.data.frame
 #'   interpolate_missing_periods interpolate_missing_periods_ madrat_mule
@@ -64,6 +65,34 @@ calcFEdemand <- function(subtype = "FE", use_ODYM_RECC = FALSE) {
       paste(rep(x,each=length(y)),y,sep=".")
     }
 
+    aggTimeSteps <- function(x, nYears = 5) {
+      periods <- sort(as.numeric(sub("^y", "", getItems(x, 2))))
+      periodsTarget <- min(periods):max(periods)
+      periodsTarget <- periodsTarget[periodsTarget %% nYears == 0]
+      periodsMissing <- setdiff(periodsTarget, periods)
+      periodsSubN <- sort(union(head(periods, -1)[diff(periods) != nYears],
+                                tail(periods, -1)[diff(periods) != nYears]))
+      periodsFill <- intersect(periodsTarget,
+                               union(periodsSubN, periodsMissing))
+      periodsKeep <- setdiff(periodsTarget, periodsFill)
+
+      periodsBuffer <- unique(do.call(c, lapply(periodsFill, function(y) {
+        (y - round(nYears / 2 - 0.1)):(y + round(nYears / 2 - 0.1))
+        })))
+      xBuffer <- time_interpolate(x, periodsBuffer)
+      rel <- expand.grid(period = periodsBuffer, periodAgg = periodsFill)
+      rel <- rel[abs(rel$period - rel$periodAgg) <= round(nYears / 2 - 0.1), ]
+      rel$w <- ifelse(abs(rel$period - rel$periodAgg) < round(nYears / 2 + 0.1), 1, 0.5)
+      w <- xBuffer
+      for (y in periodsBuffer) w[, y, ] <- unique(rel[rel$period == y, "w"])
+      rel$period <- paste0("y", rel$period)
+      rel$periodAgg <- paste0("y", rel$periodAgg)
+      xAgg <- toolAggregate(xBuffer, rel = rel, weight = w,
+                            from = "period", to = "periodAgg", dim = 2)
+      mbind(xAgg, x[, periodsKeep, ])
+    }
+
+
     addSDP_transport <- function(rmnditem){
       ## adding dummy vars and funcs to avoid global var complaints
       scenario.item  <- year <- scenario <- item <- region <- value <- variable <- .SD  <- dem_cap  <- fact <- toadd <- Year <- gdp_cap <- ssp2dem <- window <- train_add <- NULL
@@ -72,7 +101,7 @@ calcFEdemand <- function(subtype = "FE", use_ODYM_RECC = FALSE) {
       trp_nodes <- c("ueelTt", "ueLDVt", "ueHDVt")
 
       ## we work in the REMIND H12 regions to avoid strange ISO country behavior when rescaling
-      mappingfile <- toolGetMapping(type = "regional", name = "regionmappingH12.csv", 
+      mappingfile <- toolGetMapping(type = "regional", name = "regionmappingH12.csv",
                                     returnPathOnly = TRUE, where = "mappingfolder")
       rmnd_reg <- toolAggregate(rmnditem, mappingfile, from="CountryCode", to="RegionCode")
 
@@ -260,7 +289,7 @@ calcFEdemand <- function(subtype = "FE", use_ODYM_RECC = FALSE) {
       # - cumulate the reduction factor over the time horizon
 
       SSA_countries <- read_delim(
-        file = toolGetMapping(type = 'regional', name = 'regionmappingH12.csv', 
+        file = toolGetMapping(type = 'regional', name = 'regionmappingH12.csv',
         returnPathOnly = TRUE, where = "mappingfolder"),
         delim = ';',
         col_names = c('country', 'iso3c', 'region'),
@@ -364,8 +393,13 @@ calcFEdemand <- function(subtype = "FE", use_ODYM_RECC = FALSE) {
     if (subtype %in% c("FE", "EsUeFe_in", "EsUeFe_out", "FE_buildings",
                        "UE_buildings", "FE_for_Eff", "UE_for_Eff")) {
 
-      stationary <- readSource("EDGE",subtype="FE_stationary")
-      buildings  <- readSource("EDGE",subtype="FE_buildings")
+      stationary <- readSource("EDGE", subtype = "FE_stationary")
+      buildings  <- readSource("EDGE", subtype = "FE_buildings")
+
+      # aggregate to 5-year averages to suppress volatility
+      buildings <- buildings[, 2016, invert = TRUE] # all 2016 values are zero
+      buildings <- aggTimeSteps(buildings)
+      stationary <- aggTimeSteps(stationary)
 
       # filter RCP scenario
       if (subtype %in% c("FE_buildings", "UE_buildings")) {
@@ -523,7 +557,7 @@ calcFEdemand <- function(subtype = "FE", use_ODYM_RECC = FALSE) {
 
     } else if (subtype %in% c("EsUeFe_in","EsUeFe_out")){
 
-        mapping_path <- toolGetMapping(type = "sectoral", name = "structuremappingIO_EsUeFe.csv", 
+        mapping_path <- toolGetMapping(type = "sectoral", name = "structuremappingIO_EsUeFe.csv",
                                     returnPathOnly = TRUE, where = "mappingfolder")
         mapping = read.csv2(mapping_path, stringsAsFactors = F)
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.167.0**
+R package **mrremind**, version **0.167.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.167.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.167.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.167.0},
+  note = {R package version 0.167.1},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
The FE demand in buildings exists at yearly resolution for historic periods. For REMIND, we have picked every 5th year until now. To get smother trajectories and comply with our understanding that each time step represents a multi-year average, we now average the yearly historic demand in buildings to 5-year time steps.

This reduces volatility most notably for `feheb`. Below, a comparison for DEU. I did not only average EDGE-B results but also the stationary component which has yearly resolution until 2010 as it also introduced significant volatility.

![grafik](https://github.com/pik-piam/mrremind/assets/76682203/2e79952c-a6e4-4ea8-8768-01741afe2064)
