### PR TITLE
adjust calculation of GHG and CO2 emissions for UNFCCC

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '32721040'
+ValidationKey: '32750648'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.167.2
-date-released: '2023-08-01'
+version: 0.167.3
+date-released: '2023-08-07'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.167.2
-Date: 2023-08-01
+Version: 0.167.3
+Date: 2023-08-07
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcUNFCCC.R
+++ b/R/calcUNFCCC.R
@@ -47,28 +47,40 @@ calcUNFCCC <- function() {
   # aggregate pollutants ----
 
   x <- add_columns(x, "Emi|CH4 (Mt CH4/yr)", dim = 3.1)
-  x[, , "Emi|CH4 (Mt CH4/yr)"] <-
-    x[, , "Emi|CH4|Agriculture (Mt CH4/yr)"] +
-    x[, , "Emi|CH4|Energy (Mt CH4/yr)"] +
-    x[, , "Emi|CH4|Industrial Processes (Mt CH4/yr)"] +
-    x[, , "Emi|CH4|Land-Use Change (Mt CH4/yr)"] +
-    x[, , "Emi|CH4|Waste (Mt CH4/yr)"]
+  x[, , "Emi|CH4 (Mt CH4/yr)"] <- dimSums(
+    x[, , c(
+      "Emi|CH4|Agriculture (Mt CH4/yr)",
+      "Emi|CH4|Energy (Mt CH4/yr)",
+      "Emi|CH4|Industrial Processes (Mt CH4/yr)",
+      "Emi|CH4|Land-Use Change (Mt CH4/yr)",
+      "Emi|CH4|Waste (Mt CH4/yr)"
+    )],
+    dim = 3, na.rm = TRUE
+  )
 
   x <- add_columns(x, "Emi|CO2 (Mt CO2/yr)", dim = 3.1)
-  x[, , "Emi|CO2 (Mt CO2/yr)"] <-
-    x[, , "Emi|CO2|Agriculture (Mt CO2/yr)"] +
-    x[, , "Emi|CO2|Energy (Mt CO2/yr)"] +
-    x[, , "Emi|CO2|Industrial Processes (Mt CO2/yr)"] +
-    x[, , "Emi|CO2|Land-Use Change (Mt CO2/yr)"] +
-    x[, , "Emi|CO2|Waste (Mt CO2/yr)"]
+  x[, , "Emi|CO2 (Mt CO2/yr)"] <- dimSums(
+    x[, , c(
+      "Emi|CO2|Agriculture (Mt CO2/yr)",
+      "Emi|CO2|Energy (Mt CO2/yr)",
+      "Emi|CO2|Industrial Processes (Mt CO2/yr)",
+      "Emi|CO2|Land-Use Change (Mt CO2/yr)",
+      "Emi|CO2|Waste (Mt CO2/yr)"
+    )],
+    dim = 3, na.rm = TRUE
+  )
 
   x <- add_columns(x, "Emi|N2O (kt N2O/yr)", dim = 3.1)
-  x[, , "Emi|N2O (kt N2O/yr)"] <-
-    x[, , "Emi|N2O|Agriculture (kt N2O/yr)"] +
-    x[, , "Emi|N2O|Energy (kt N2O/yr)"] +
-    x[, , "Emi|N2O|Industrial Processes (kt N2O/yr)"] +
-    x[, , "Emi|N2O|Land-Use Change (kt N2O/yr)"] +
-    x[, , "Emi|N2O|Waste (kt N2O/yr)"]
+  x[, , "Emi|N2O (kt N2O/yr)"] <- dimSums(
+    x[, , c(
+      "Emi|N2O|Agriculture (kt N2O/yr)",
+      "Emi|N2O|Energy (kt N2O/yr)",
+      "Emi|N2O|Industrial Processes (kt N2O/yr)",
+      "Emi|N2O|Land-Use Change (kt N2O/yr)",
+      "Emi|N2O|Waste (kt N2O/yr)"
+    )],
+    dim = 3, na.rm = TRUE
+  )
 
   # add total GHG as CO2 equivalents for sectors ----
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.167.2**
+R package **mrremind**, version **0.167.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.167.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.167.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.167.2},
+  note = {R package version 0.167.3},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This should solve #411  by setting missing values in the calculations to 0.

`Emi|CO2`, `Emi|CH4`, `Emi|N2O` will be calculated even if any of the sectors do not have a value. This will produce values for `Emi|GHG` and `Emi|CO2` that were not present before.