### PR TITLE
move industry_specifc_FE_limits subtype from ExpertGuess to industry_subsector_specifc source

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '32978974'
+ValidationKey: '33144280'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.168.2
-date-released: '2023-09-07'
+version: 0.169.0
+date-released: '2023-09-12'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.168.2
-Date: 2023-09-07
+Version: 0.169.0
+Date: 2023-09-12
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFEdemand.R
+++ b/R/calcFEdemand.R
@@ -1693,7 +1693,7 @@ calcFEdemand <- function(subtype = "FE", use_ODYM_RECC = FALSE) {
       # scale industry subsector total FE by subsector activity and exogenous
       # energy efficiency gains
 
-      specific_FE_limits <- readSource(type = 'ExpertGuess',
+      specific_FE_limits <- readSource(type = 'industry_subsectors_specific',
                                        subtype = 'industry_specific_FE_limits',
                                        convert = FALSE) %>%
         madrat_mule()

--- a/R/calcindustry_specific_FE_limits.R
+++ b/R/calcindustry_specific_FE_limits.R
@@ -1,7 +1,7 @@
 #' Thermodynamic Limits for Industry Specific FE Demand
 #'
-#' Return `readExpertGuess('industry_specific_FE_limits')` in a format usable as
-#' a REMIND input.
+#' Return `readindustry_subsectors_specific('industry_specific_FE_limits')` in a
+#' format usable as a REMIND input.
 #'
 #' @md
 #' @return A [`magpie`][magclass::magclass] object.
@@ -15,7 +15,7 @@
 
 #' @export
 calcindustry_specific_FE_limits <- function() {
-  return(list(x = readSource(type = 'ExpertGuess',
+  return(list(x = readSource(type = 'industry_subsectors_specific',
                              subtype = 'industry_specific_FE_limits',
                              convert = FALSE) %>%
                 madrat_mule() %>%

--- a/R/industry_subsectors_specific.R
+++ b/R/industry_subsectors_specific.R
@@ -94,7 +94,15 @@ readindustry_subsectors_specific <- function(subtype = NULL) {
                comment = '#',
                progress = FALSE) %>%
         madrat_mule()
-    })
+    },
+
+    'industry_specific_FE_limits' = function() {
+      read_csv(file = file.path(path, 'industry_specific_FE_limits.csv'),
+               comment = '#',
+               show_col_types = FALSE) %>%
+        madrat_mule()
+    }
+  )
 
   # check if the subtype called is available ----
   if (!subtype %in% names(switchboard)) {

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -68,11 +68,6 @@ readExpertGuess <- function(subtype) {
                     comment = '#',
                     show_col_types = FALSE) %>%
       madrat_mule()
-  } else if ('industry_specific_FE_limits' == subtype) {
-    out <- read_csv(file = file.path(path, 'industry_specific_FE_limits.csv'),
-                    comment = '#',
-                    show_col_types = FALSE) %>%
-      madrat_mule()
   } else if ('industry_max_secondary_steel_share' == subtype) {
     out <- read_csv(
       file = file.path(path, 'industry_max_secondary_steel_share.csv'),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.168.2**
+R package **mrremind**, version **0.169.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.168.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.169.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.168.2},
+  note = {R package version 0.169.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
The industry_specific_FE_limits.csv file is hard-linked between both sources for now, but could be deleted from ExpertGuess after a year or so.