### PR TITLE
abort generation of validation data in case of an error

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '33186888'
+ValidationKey: '33208195'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.169.2
-date-released: '2023-09-14'
+version: 0.169.3
+date-released: '2023-09-15'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.169.2
-Date: 2023-09-14
+Version: 0.169.3
+Date: 2023-09-15
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/fullVALIDATIONREMIND.R
+++ b/R/fullVALIDATIONREMIND.R
@@ -43,25 +43,25 @@ fullVALIDATIONREMIND <- function(rev = 0) {
 
   calcOutput("Historical",
     round = 5, file = valfile, aggregate = columnsForAggregation,
-    append = FALSE, warnNA = FALSE, try = TRUE
+    append = FALSE, warnNA = FALSE, try = FALSE
   )
 
   calcOutput(
     type = "IEA_ETP", aggregate = columnsForAggregation, file = valfile,
-    append = TRUE, warnNA = FALSE, try = TRUE, isValidation = TRUE
+    append = TRUE, warnNA = FALSE, try = FALSE, isValidation = TRUE
   )
 
   ## industry value added ----
   calcOutput(
     type = "UNIDO", subtype = "INDSTAT2", file = valfile,
     aggregate = columnsForAggregation, append = TRUE, warnNA = FALSE,
-    try = TRUE
+    try = FALSE
   )
 
   ## add WEO data on regional and global level ----
   weo <- calcOutput(
     type = "IEA_WEO_2021", subtype = "global", aggregate = columnsForAggregation,
-    warnNA = FALSE, try = TRUE, isValidation = TRUE
+    warnNA = FALSE, try = FALSE, isValidation = TRUE
   )
 
   weo <- weo["GLO", , ]
@@ -69,7 +69,7 @@ fullVALIDATIONREMIND <- function(rev = 0) {
 
   weo <- calcOutput(
     type = "IEA_WEO_2021", subtype = "region", aggregate = columnsForAggregation,
-    warnNA = FALSE, try = TRUE, isValidation = TRUE
+    warnNA = FALSE, try = FALSE, isValidation = TRUE
   )
 
   weo <- weo["GLO", , invert = TRUE]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.169.2**
+R package **mrremind**, version **0.169.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.169.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.169.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.169.2},
+  note = {R package version 0.169.3},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Input data generation for the historical.mif has been failing for over 2 months and we did not notice it, because the fullVALIDATIONREMIND carried on with processing.  During that time, three bugs got into mrremind and mrcommons without us noticing it.

I changed the setting to crash in that case.
