### PR TITLE
make sure that years are not lost when reading in worldsteel

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '33401600'
+ValidationKey: '33421248'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.170.0
+version: 0.170.1
 date-released: '2023-10-18'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.170.0
+Version: 0.170.1
 Date: 2023-10-18
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcIEA_EVOutlook.R
+++ b/R/calcIEA_EVOutlook.R
@@ -51,6 +51,8 @@ calcIEA_EVOutlook <- function() {
   # set 0s in other CHA countries than China to approximate CHA as China
   x[c("HKG", "MAC", "TWN"),,] <- 0
 
+  x <- add_dimension(x, dim = 3.1, add = "scenario", nm = "historical")
+
   return(list(
     x = x,
     weight = NULL,

--- a/R/readworldsteel.R
+++ b/R/readworldsteel.R
@@ -56,7 +56,8 @@ readworldsteel <- function(subtype = 'detailed') {
           read_ods(path = file_path, sheet = sheet, na = '...') %>%
             as_tibble() %>%
             mutate(name = sheet) %>%
-            pivot_longer(c(-'country', -'name'), names_to = 'year', names_transform = list(year = as.integer))
+            pivot_longer(c(-'country', -'name'), names_to = 'year') %>%
+            mutate(year := as.integer(gsub("^X", "", year)))
         }) %>%
         bind_rows() %>%
         add_countrycode_(origin = c(country = 'country.name'),

--- a/R/readworldsteel.R
+++ b/R/readworldsteel.R
@@ -57,7 +57,7 @@ readworldsteel <- function(subtype = 'detailed') {
             as_tibble() %>%
             mutate(name = sheet) %>%
             pivot_longer(c(-'country', -'name'), names_to = 'year') %>%
-            mutate(year := as.integer(gsub("^X", "", year)))
+            mutate(!!sym("year") := as.integer(gsub("^X", "", !!sym("year"))))
         }) %>%
         bind_rows() %>%
         add_countrycode_(origin = c(country = 'country.name'),

--- a/R/readworldsteel.R
+++ b/R/readworldsteel.R
@@ -56,8 +56,9 @@ readworldsteel <- function(subtype = 'detailed') {
           read_ods(path = file_path, sheet = sheet, na = '...') %>%
             as_tibble() %>%
             mutate(name = sheet) %>%
-            pivot_longer(c(-'country', -'name'), names_to = 'year') %>%
-            mutate(!!sym("year") := as.integer(gsub("^X", "", !!sym("year"))))
+            pivot_longer(c(-'country', -'name'), names_to = 'year',
+                         names_transform = list(year = function(x) {
+                           as.integer(sub('^X', '', x)) }))
         }) %>%
         bind_rows() %>%
         add_countrycode_(origin = c(country = 'country.name'),

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.170.0, <URL: https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.170.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.170.0**
+R package **mrremind**, version **0.170.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.170.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.170.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.170.0},
+  note = {R package version 0.170.1},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Currently input data generation fails because years are lost when reading in worldsteel. Expects column names as numbers, but they are read in as X2005, X2010 ...

```
~ Run readSource(type = "worldsteel", convert = FALSE)
~~ WARNING: NAs introduced by coercion
~~ WARNING: NAs introduced by coercion
~~ WARNING: NAs introduced by coercion
~~ WARNING: NAs introduced by coercion
~~ WARNING: NAs introduced by coercion
~~ WARNING: NAs introduced by coercion
~~ WARNING: NAs introduced by coercion
~~ ERROR: 
~~ error in evaluating the argument 'x' in selecting a method for function 'as.magpie': error in evaluating the argument 'x' in selecting a method for function 'as.data.frame': NAs are not allowed in subscripted assignments
Error in `h()`:
! error in evaluating the argument 'x' in selecting a method for function 'as.magpie': error in evaluating the argument 'x' in selecting a method for function 'as.data.frame': NAs are not allowed in subscripted assignments
```