### PR TITLE
fix regression of industry per-capita Value Added

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '33483600'
+ValidationKey: '33513480'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.170.4
-date-released: '2023-10-20'
+version: 0.170.5
+date-released: '2023-10-26'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.170.4
-Date: 2023-10-20
+Version: 0.170.5
+Date: 2023-10-26
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/EDGE-Industry.R
+++ b/R/EDGE-Industry.R
@@ -1476,7 +1476,7 @@ calcIndustry_Value_Added <- function(subtype = 'physical',
       nls(formula = manufacturing / population ~ a * exp(b / GDPpC),
           data = regression_data %>%
             filter(.data$region == r,
-                   'Total' != .data$iso3c),
+                   'Total' == .data$iso3c),
           start = list(a = 1000, b = -2000),
           trace = FALSE) %>%
         tidy() %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.170.4**
+R package **mrremind**, version **0.170.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.170.4, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.170.5, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.170.4},
+  note = {R package version 0.170.5},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
A bug in the industry Value Added regression lead to wrong demand numbers for Other Industry, from #408/`v0.165.0` onwards.  Affected are all input data revisions after July 13
```
rev6.542APT-2023-07-16           mrremind  0.164.2
rev6.544                         mrremind  0.166.0
rev6.542APT-2023-08-06           mrremind  0.167.2
rev6.51campaigners               mrremind  0.168.0
rev6.542APT-2023-09-03           mrremind  0.168.1
rev6.542APT-2023-09-10           mrremind  0.168.2
rev6.542APT-2023-09-17           mrremind  0.169.3
rev6.542APT-2023-09-24           mrremind  0.169.4
rev6.543trspARIADNEchanges       mrremind  0.169.4
rev6.542APT-2023-10-01           mrremind  0.169.4
rev6.542APT-2023-10-08           mrremind  0.169.4
rev6.544trspARIADNEchanges       mrremind  0.169.4
rev6.545trspARIADNEchanges       mrremind  0.169.4
rev6.542APT-2023-10-15           mrremind  0.169.4
rev6.55ARIADNEtrsp               mrremind  0.169.4
rev6.56-test_SSP5_industry       mrremind  0.170.1
rev6.545                         mrremind  0.170.1
rev6.56-test_SSP5_industry       mrremind  0.170.1
rev6.545                         mrremind  0.170.1
rev6.57ARIADNEtrsp               mrremind  0.170.2
rev6.56-test_SSP5_industry_fix1  mrremind  0.170.2.9001
rev6.56-test_SSP5_industry_fix2  mrremind  0.170.2.9002
rev6.542falks-cache              mrremind  0.170.3
rev6.542APT-2023-10-22           mrremind  0.170.3
```
and all REMIND calibrations based on those input data revisions.

REMIND runs using these input data revisions, but a calibration based on prior input data (i.e. up to https://github.com/remindmodel/CESparameters/commit/ce96f1f97389c0b49757726259a40754a3c930b3) are not affected.  (https://github.com/remindmodel/CESparameters/commit/216c0ede4f08158971a8aa8a80de94387e031809 is lacking provenance, so it is not possible to tell.)