### PR TITLE
update NDCs with cutoff data 2023-11-29

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '34074080'
+ValidationKey: '34274520'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.173.0
-date-released: '2023-12-05'
+version: 0.174.0
+date-released: '2023-12-07'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.173.0
-Date: 2023-12-05
+Version: 0.174.0
+Date: 2023-12-07
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -18,7 +18,7 @@ readUNFCCC_NDC <- function(subtype) {
   } else if (grepl("2022", subtype, fixed = TRUE)) {
     NDCfile <- "NDC_2022-12-31.xlsx"
   } else {
-    NDCfile <- "NDC_2023-05-31.xlsx"
+    NDCfile <- "NDC_2023-11-29.xlsx"
     if (!grepl("2023", subtype, fixed = TRUE)) {
       warning("\nNo data for year in ", subtype, " available. Choose default: ", NDCfile)
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.173.0**
+R package **mrremind**, version **0.174.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.173.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2023). _mrremind: MadRat REMIND Input Data Package_. R package version 0.174.0, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2023},
-  note = {R package version 0.173.0},
+  note = {R package version 0.174.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
update NDCs with cutoff data 2023-11-29, Includes those updates since March 31:
- [EU](https://unfccc.int/sites/default/files/NDC/2023-10/ES-2023-10-17%20EU%20submission%20NDC%20update.pdf)
- [Oman](https://unfccc.int/sites/default/files/NDC/2023-11/Oman%201st%20Update%20of%20the%202nd%20NDC%20-%20Optimized%20Size%20%281%29.pdf)
- [Brazil](https://unfccc.int/sites/default/files/NDC/2023-11/Brazil%20First%20NDC%202023%20adjustment.pdf)
- [Azerbaijan](https://unfccc.int/sites/default/files/NDC/2023-10/Second%20NDC_Azerbaijan_ENG_Final%20%281%29.pdf)
- [United Arab Emirates](https://unfccc.int/sites/default/files/NDC/2023-07/Third%20Update%20of%20Second%20NDC%20for%20the%20UAE_v15.pdf)
- [Kazakhstan](https://unfccc.int/sites/default/files/NDC/2023-06/12updated%20NDC%20KAZ_Gov%20Decree313_19042023_en_cover%20page.pdf)
- [Egypt](https://unfccc.int/sites/default/files/NDC/2023-06/Egypts%20Updated%20First%20Nationally%20Determined%20Contribution%202030%20%28Second%20Update%29.pdf)

Runs and cs2 are here: /p/tmp/rahelma/NDCupdate/remind-3.2/remind

- Note: EUR is based on regipol.

Changes: Factors compared to 2005 emissions

- 2030,LAM,2023_cond: 0.7622 -> 0.7519
- 2030,MEA,2023_cond: 1.2097 -> 0.9692
- 2050,REF,2023_cond: 0 -> 0.0917
- 2030,LAM,2023_uncond: 0.7809 -> 0.7703
- 2030,MEA,2023_uncond: 1.1233 -> 1.0695

2005 GHG emission share of countries with quantifyable emissions under NDC in particular region per target year

- 2050,REF,2023_cond: 0.0948 -> 0.1081

Strengthening of NDCs. Because a country with low ambitions has added a 2050 goal in REF, the coverage is extended, but the emission reduction goal for those with coverage is higher. That seems fine.

![image](https://github.com/pik-piam/mrremind/assets/90761609/f93c2e7f-ed53-44ee-8833-8b3966f41791)
![image](https://github.com/pik-piam/mrremind/assets/90761609/811e4895-0ecc-4c1e-a07e-7807deef3bd0)
