### PR TITLE
IEA Global EV Data extention

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '34396362'
+ValidationKey: '34428304'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.174.3
-date-released: '2024-01-12'
+version: 0.174.4
+date-released: '2024-01-19'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.174.3
-Date: 2024-01-12
+Version: 0.174.4
+Date: 2024-01-19
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),
@@ -81,4 +81,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: no
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.174.3**
+R package **mrremind**, version **0.174.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.174.3, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.174.4, <URL: https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2024},
-  note = {R package version 0.174.3},
+  note = {R package version 0.174.4},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/inst/extdata/reportingVariables/Mapping_IEA_EV_Outlook.csv
+++ b/inst/extdata/reportingVariables/Mapping_IEA_EV_Outlook.csv
@@ -16,15 +16,15 @@ EV sales share|Vans|EV;percent;;;;
 EV sales|Buses|BEV;no;Sales|Transport|Bus|Electric;Million vehicles;;1.00E-06
 EV sales|Buses|PHEV;no;;;;
 EV sales|Buses|FCEV;no;Sales|Transport|Bus|FCEV;Million vehicles;;1.00E-06
-EV sales|Cars|BEV;no;;;;
-EV sales|Cars|PHEV;no;;;;
-EV sales|Cars|FCEV;no;;;;
-EV sales|Trucks|BEV;no;;;;
-EV sales|Trucks|FCEV;no;;;;
+EV sales|Cars|BEV;no;Sales|Transport|Car|Electric;Million vehicles;;1.00E-06
+EV sales|Cars|PHEV;no;Sales|Transport|Car|Hybrid Electric;Million vehicles;;1.00E-06
+EV sales|Cars|FCEV;no;Sales|Transport|Car|FCEV;Million vehicles;;1.00E-06
+EV sales|Trucks|BEV;no;Sales|Transport|Truck|Electric;Million vehicles;;1.00E-06
+EV sales|Trucks|FCEV;no;Sales|Transport|Truck|FCEV;Million vehicles;;1.00E-06
 EV sales|Trucks|PHEV;no;;;;
-EV sales|Vans|BEV;no;;;;
-EV sales|Vans|PHEV;no;;;;
-EV sales|Vans|FCEV;no;;;;
+EV sales|Vans|BEV;no;Sales|Transport|LDV|Van|BEV;Million vehicles;;1.00E-06
+EV sales|Vans|PHEV;no;Sales|Transport|LDV|Van|Hybrid Electric;Million vehicles;;1.00E-06
+EV sales|Vans|FCEV;no;Sales|Transport|LDV|Van|FCEV;Million vehicles;;1.00E-06
 EV stock share|Buses|EV;percent;;;;
 EV stock share|Cars|EV;percent;;;;
 EV stock share|Trucks|EV;percent;;;;
@@ -32,15 +32,15 @@ EV stock share|Vans|EV;percent;;;;
 EV stock|Buses|BEV;no;Stock|Transport|Bus|Electric;Million vehicles;;1.00E-06
 EV stock|Buses|PHEV;no;;;;
 EV stock|Buses|FCEV;no;Stock|Transport|Bus|FCEV;Million vehicles;;1.00E-06
-EV stock|Cars|BEV;no;;;;
-EV stock|Cars|PHEV;no;;;;
-EV stock|Cars|FCEV;no;;;;
-EV stock|Trucks|BEV;no;;;;
-EV stock|Trucks|FCEV;no;;;;
+EV stock|Cars|BEV;no;Stock|Transport|Car|Electric;Million vehicles;;1.00E-06
+EV stock|Cars|PHEV;no;Stock|Transport|Car|Hybrid Electric;Million vehicles;;1.00E-06
+EV stock|Cars|FCEV;no;Sales|Transport|Car|FCEV;Million vehicles;;1.00E-06
+EV stock|Trucks|BEV;no;Stock|Transport|Truck|Electric;Million vehicles;;1.00E-06
+EV stock|Trucks|FCEV;no;Stock|Transport|Truck|FCEV;Million vehicles;;1.00E-06
 EV stock|Trucks|PHEV;no;;;;
-EV stock|Vans|BEV;no;;;;
-EV stock|Vans|PHEV;no;;;;
-EV stock|Vans|FCEV;no;;;;
+EV stock|Vans|BEV;no;Stock|Transport|LDV|Van|BEV;Million vehicles;;1.00E-06
+EV stock|Vans|PHEV;no;Stock|Transport|LDV|Van|Hybrid Electric;Million vehicles;;1.00E-06
+EV stock|Vans|FCEV;no;Stock|Transport|LDV|Van|FCEV;Million vehicles;;1.00E-06
 Oil displacement|Buses|EV;Milion liters of gasoline equivalent;;;;
 Oil displacement|Buses|BEV;Milion liters of gasoline equivalent;;;;
 Oil displacement|Buses|PHEV;Milion liters of gasoline equivalent;;;;

--- a/man/fullVALIDATIONREMIND.Rd
+++ b/man/fullVALIDATIONREMIND.Rd
@@ -2,12 +2,14 @@
 % Please edit documentation in R/fullVALIDATIONREMIND.R
 \name{fullVALIDATIONREMIND}
 \alias{fullVALIDATIONREMIND}
-\title{fullVALIDATIONREMIND}
+\title{Generate Validation Data for REMIND}
 \usage{
-fullVALIDATIONREMIND(years = NULL)
+fullVALIDATIONREMIND(rev = 0, years = NULL)
 }
 \arguments{
-\item{years}{A vector of years that should be returned. If set to NULL all
+\item{rev}{Unused parameter here for the pleasure of \code{\link{madrat}}.}
+
+\item{years}{A vector of years that should be returned. If set to \code{NULL} all
 available years are returned.}
 }
 \description{
@@ -18,10 +20,10 @@ REMIND model results can be compared.
 \dontrun{
 fullVALIDATIONREMIND()
 }
-
 }
 \seealso{
-\code{\link{fullREMIND}},\code{\link{readSource}},\code{\link{getCalculations}},\code{\link{calcOutput}}
+\code{\link[=fullREMIND]{fullREMIND()}}, \code{\link[=readSource]{readSource()}}, \code{\link[=getCalculations]{getCalculations()}},
+\code{\link[=calcOutput]{calcOutput()}}
 }
 \author{
 David Klein, Falk Benke


### PR DESCRIPTION
Extending [Mapping_IEA_EV_Outlook.csv](https://github.com/pik-piam/mrremind/pull/462/commits/8269726d57e687463da33ee1bea1cadf7b6053ff#diff-b3344af23230e68e5d0dfde6340a195f20ab700fcd5a01f7f92f0133a16c6070) to REMIND variables of EV trucks and vans and create non-REMIND variable EV cars that would correspond to the sum of 
```
Compact Car
Large Car
Midsize Car
Mini Car
Subcompact Car
```