### PR TITLE
refactor reading in UNFCCC data

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '346207720'
+ValidationKey: '346385091'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.175.10
-date-released: '2024-02-19'
+version: 0.175.11
+date-released: '2024-02-28'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.175.10
-Date: 2024-02-19
+Version: 0.175.11
+Date: 2024-02-28
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcUNFCCC.R
+++ b/R/calcUNFCCC.R
@@ -44,8 +44,6 @@ calcUNFCCC <- function() {
     as.magpie() %>%
     toolCountryFill(fill = NA, verbosity = 2)
 
-  mappedVariables <- getNames(x)
-
   # aggregate pollutants ----
 
   x <- add_columns(x, "Emi|CH4 (Mt CH4/yr)", dim = 3.1)
@@ -238,11 +236,14 @@ calcUNFCCC <- function() {
 
   # return results ----
 
-  # set 0 to NA in calculated variables
-  calculatedVariabes <- setdiff(getNames(x), mappedVariables)
-  tmp <- x[, , calculatedVariabes]
-  tmp[tmp == 0] <- NA
-  x[, , calculatedVariabes] <- tmp
+  # fill countries of selected regions with 0 to allow for regional aggregation
+  regions.fill <- c("EUR", "REF", "NEU", "CAZ")
+  mapping <- toolGetMapping("regionmappingH12.csv", type = "regional", where = "mappingfolder") %>%
+    filter(.data$RegionCode %in% regions.fill)
+
+  tmp <- x[unique(mapping$CountryCode), , ]
+  tmp[is.na(tmp)] <- 0
+  x[unique(mapping$CountryCode), , ] <- tmp
 
   # remove years before 1990 due to incomplete data
   x <- x[, seq(1986, 1989, 1), , invert = TRUE]

--- a/R/convertUNFCCC.R
+++ b/R/convertUNFCCC.R
@@ -1,43 +1,29 @@
 #' Convert UNFCCC data
-#' 
+#'
 #' @md
-#' @param x A [`magpie`][magclass::magclass] object returned from 
+#' @param x A [`magpie`][magclass::magclass] object returned from
 #'          [`readUNFCCC()`].
 #'
 #' @return A [`magpie`][magclass::magclass] object.
-#' 
+#'
 #' @author Falk Benke
-#' 
-#' @importFrom dplyr %>% mutate select
-#' @importFrom madrat getISOlist
-#' @importFrom magclass as.data.frame as.magpie
-#' @importFrom quitte character.data.frame
-#' @importFrom rlang sym syms
-#' @importFrom tibble as_tibble
-#' @importFrom tidyr complete nesting
-#' 
+#'
+#' @importFrom dplyr %>% filter
+#' @importFrom madrat toolCountryFill toolGetMapping
+#'
 #' @export
-convertUNFCCC <- function(x)
-{
-  x <- as.data.frame(x) %>% 
-    as_tibble() %>% 
-    select('region' = 'Region', 'variable' = 'Data1', 'unit' = 'Data2', 
-           'year' = 'Year', 'value' = 'Value') %>% 
-    character.data.frame() %>%
-    filter(!!sym("region") %in% getISOlist()) %>%
-    mutate(year = as.integer(!!sym('year'))) %>%
-    complete(nesting(!!!syms(c('variable', 'unit', 'year'))),
-             region = setNames(getISOlist(), NULL)) %>% 
-    as.magpie(tidy = TRUE)
-  
+convertUNFCCC <- function(x) {
+
+  x <- toolCountryFill(x, verbosity = 2, no_remove_warning = "EUA")
+
   # fill countries of selected regions with 0 to allow for region aggregation
   regions.fill <- c("EUR", "REF", "NEU", "CAZ")
-  mapping <- toolGetMapping("regionmappingH12.csv", type = "regional", where = "mappingfolder") %>% filter(
-    !!sym("RegionCode") %in% regions.fill
-  )
-  tmp <- x[unique(mapping$CountryCode),,]
+  mapping <- toolGetMapping("regionmappingH12.csv", type = "regional", where = "mappingfolder") %>%
+    filter(.data$RegionCode %in% regions.fill)
+
+  tmp <- x[unique(mapping$CountryCode), , ]
   tmp[is.na(tmp)] <- 0
-  x[unique(mapping$CountryCode),,] <- tmp
+  x[unique(mapping$CountryCode), , ] <- tmp
 
   return(x)
 }

--- a/R/convertUNFCCC.R
+++ b/R/convertUNFCCC.R
@@ -8,22 +8,10 @@
 #'
 #' @author Falk Benke
 #'
-#' @importFrom dplyr %>% filter
-#' @importFrom madrat toolCountryFill toolGetMapping
+#' @importFrom madrat toolCountryFill
 #'
 #' @export
 convertUNFCCC <- function(x) {
-
   x <- toolCountryFill(x, verbosity = 2, no_remove_warning = "EUA")
-
-  # fill countries of selected regions with 0 to allow for region aggregation
-  regions.fill <- c("EUR", "REF", "NEU", "CAZ")
-  mapping <- toolGetMapping("regionmappingH12.csv", type = "regional", where = "mappingfolder") %>%
-    filter(.data$RegionCode %in% regions.fill)
-
-  tmp <- x[unique(mapping$CountryCode), , ]
-  tmp[is.na(tmp)] <- 0
-  x[unique(mapping$CountryCode), , ] <- tmp
-
   return(x)
 }

--- a/R/readUNFCCC.R
+++ b/R/readUNFCCC.R
@@ -24,6 +24,7 @@
 readUNFCCC <- function() {
 
   # structural definition of the source ----
+  # nolint start
   sheets <- list(
     "Table1s1" = list(
       range = "A7:H26",
@@ -437,6 +438,7 @@ readUNFCCC <- function() {
       )
     )
   )
+  # nolint end
 
   # parse directories ----
 
@@ -467,7 +469,7 @@ readUNFCCC <- function() {
         if (!is.null(sheets[[i]][["extraVariables"]])) {
           extra <- suppressMessages(
             read_xlsx(path = file.path("2023", dir, file), sheet = i) %>%
-            select(seq(1:4))
+              select(seq(1:4))
           )
           colnames(extra) <- c("variable", sheets[[i]][["colnames"]])
           extra <- extra %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.175.10**
+R package **mrremind**, version **0.175.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.175.10, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.175.11, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux},
   year = {2024},
-  note = {R package version 0.175.10},
+  note = {R package version 0.175.11},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This PR simplifies logic in convertUNFCCC by using madrat functions and unifies handling of 0s vs NAs in calcUNFCCC:
all countries in regions "EUR", "REF", "NEU", "CAZ" are set to 0s if they have NAs so regional aggregation yields results.

Before, this was limited only to data read in from the source, now it also includes data calculated on top of read in data.


This fixes the problem that
`Emi|CO2|Industrial Processes` and `Emi|CO2|Energy|Demand|Industry` are available for EU27 and CAZ, but `Emi|CO2|Industry ` is not.