### PR TITLE
add capacity factor for biogasc

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35370660'
+ValidationKey: '35397648'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.178.1
-date-released: '2024-05-17'
+version: 0.178.2
+date-released: '2024-05-21'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark
@@ -64,5 +64,6 @@ authors:
 - family-names: Koch
   given-names: Johannes
 license: LGPL-3.0
+keywords: ~
 repository-code: https://github.com/pik-piam/mrremind
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.178.1
-Date: 2024-05-17
+Version: 0.178.2
+Date: 2024-05-21
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readREMIND_11Regi.R
+++ b/R/readREMIND_11Regi.R
@@ -31,7 +31,7 @@ readREMIND_11Regi <- function(subtype) {
     },
     "deltacapoffset"       = read.csv("p_adj_deltacapoffset.csv", sep = ";")    %>% as.magpie(datacol = 2),
     "capacityFactorGlobal" = {
-      x <- read.csv("f_cf-global.csv", sep = ";")
+      x <- read.csv("f_cf-global_REMIND_3.3.4.csv", sep = ";")
       x[x$Tech == "rockgrind", "Tech"] <- "weathering"
       as.magpie(x, datacol = 2)
     },
@@ -63,11 +63,11 @@ readREMIND_11Regi <- function(subtype) {
       x
     },
     "uraniumExtractionCoeff" = read.csv("uranium_extraction_cost_eq_coefficients.csv", sep = ";") %>%
-      as.magpie( spatial = 1, temporal = 0, datacol = 3),
+      as.magpie(spatial = 1, temporal = 0, datacol = 3),
     "RLDCCoefficientsLoB"    = read.csv("RLDC_Coefficients_LoB.csv", sep = ";") %>%
-      as.magpie( spatial = 1, temporal = 0, datacol = 3),
+      as.magpie(spatial = 1, temporal = 0, datacol = 3),
     "RLDCCoefficientsPeak"   = read.csv("RLDC_Coefficients_Peak.csv", sep = ";") %>%
-      as.magpie( spatial = 1, temporal = 0, datacol = 3),
+      as.magpie(spatial = 1, temporal = 0, datacol = 3),
     "earlyRetirementAdjFactor" = {
       y <- read.csv("earlyRetirementAdjFactor.csv", sep = ";", skip = 5)
       x <- as.magpie(y, spatial = 1, temporal = 0, datacol = 2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.178.1**
+R package **mrremind**, version **0.178.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.178.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.178.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.178.1},
+  note = {R package version 0.178.2},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
According to the https://github.com/remindmodel/remind/pull/859 that introduces the technology biogasc, the technology is supposed to have the same capacity factor as the biogas tech without capture (pm_cf = 0.91).

It will be written to the file `f_cf.cs3r` in the inputdata.

This replaces this closed PR: https://github.com/remindmodel/remind/pull/1672