### PR TITLE
Fix warnings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '35601664'
+ValidationKey: '35634082'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.179.2
-date-released: '2024-05-24'
+version: 0.179.3
+date-released: '2024-05-31'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.179.2
-Date: 2024-05-24
+Version: 0.179.3
+Date: 2024-05-31
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcIO.R
+++ b/R/calcIO.R
@@ -33,50 +33,64 @@ calcIO <- function(subtype = c("input", "output", "output_biomass", "trade",
   switch(
     subtype,
     input = {
-      mapping <- "structuremappingIO_inputs.csv"
-      where <- "mrremind"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_inputs.csv",
+                                where = "mrremind",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech")
     },
     output = {
-      mapping <- "structuremappingIO_outputs.csv"
-      where <- "mrcommons"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_outputs.csv",
+                                where = "mrcommons",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech")
     },
     output_biomass = {
-      mapping <- "structuremappingIO_outputs.csv"
-      where <- "mrcommons"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_outputs.csv",
+                                where = "mrcommons",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech")
     },
     trade = {
-      mapping <- "structuremappingIO_trade.csv"
-      where <- "mrremind"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_trade.csv",
+                                where = "mrremind",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_enty", "REMINDitems_trade")
     },
     input_Industry_subsectors = {
-      mapping <- "structuremappingIO_inputs_Industry_subsectors.csv"
-      where <- "mrremind"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_inputs_Industry_subsectors.csv",
+                                where = "mrremind",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech")
     },
     output_Industry_subsectors = {
-      mapping <- "structuremappingIO_outputs_Industry_subsectors.csv"
-      where <- "mrremind"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_outputs_Industry_subsectors.csv",
+                                where = "mrremind",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech")
     },
     IEA_output = {
-      mapping <- "structuremappingIO_outputs.csv"
-      where <- "mrcommons"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_outputs.csv",
+                                where = "mrcommons",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech",
                   "iea_product", "iea_flows")
     },
     IEA_input = {
-      mapping <- "structuremappingIO_inputs.csv"
-      where <- "mrremind"
+      mapping <- toolGetMapping(type = "sectoral",
+                                name = "structuremappingIO_inputs.csv",
+                                where = "mrremind",
+                                returnPathOnly = TRUE)
       target <- c("REMINDitems_in", "REMINDitems_out", "REMINDitems_tech",
                   "iea_product", "iea_flows")
     }
   )
-  mapping <- toolGetMapping(type = "sectoral", name = mapping, where = where,
-                            returnPathOnly = TRUE)
 
   if (!(ieaVersion %in% c("default", "latest"))) {
     stop("Invalid parameter `ieaVersion`. Must be either 'default' or 'latest'")

--- a/R/readGGDC10.R
+++ b/R/readGGDC10.R
@@ -12,12 +12,10 @@
 
 readGGDC10 <- function() {
 
-  Sector <- Value <- NULL # empty declarations of variables used in dplyr operations
-
-  data <- read_xlsx(path = "ggdc10.xlsx", sheet = "dataset")
+  data <- suppressWarnings(read_xlsx(path = "ggdc10.xlsx", sheet = "dataset"))
 
   dataLong <- data[, -c(2, 3)] %>%
-    gather(Sector, Value, -c(1:3))
+    gather("Sector", "Value", -c(1:3))
 
   x <- as.magpie(dataLong, spatial = 1, temporal = 3, datacol = 5)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.179.2**
+R package **mrremind**, version **0.179.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.179.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.179.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.179.2},
+  note = {R package version 0.179.3},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This fixes two obnoxious warnings in inputdata generation
1. This type of warnings is spamming the log and has its origin in `readGGDC10`: `Expecting numeric in O7550 / R7550C15: got 'incl in gov. services'`
2. Apparently madrat does static code analysis when loading it and throws a misleading warning when you call toolGetMapping with parameters, as done previously in calcIO. Therefore, I rewrote it to a more explicit (but more redundant) version that madrat should understand (cc @0UmfHxcvx5J7JoaOhFSs5mncnisTJJ6q )