### PR TITLE
fix error in calcCO2Prices

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '36306550'
+ValidationKey: '36326444'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.182.5
+version: 0.182.6
 date-released: '2024-06-20'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.182.5
+Version: 0.182.6
 Date: 2024-06-20
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcCO2Prices.R
+++ b/R/calcCO2Prices.R
@@ -1,5 +1,4 @@
 calcCO2Prices <- function() {
-
   # read data
   x <- readSource("ExpertGuess", subtype = "co2prices")
   getNames(x) <- NULL
@@ -8,20 +7,12 @@ calcCO2Prices <- function() {
   ceds <- calcOutput("Emissions", datasource = "CEDS2024", aggregate = FALSE)
   ceds <- ceds[, , "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)"]
 
-  # if most recent year is not in ceds, use latest ceds year that is available
-  cedsyears <- getYears(ceds, as.integer = TRUE)
-  xyears <- getYears(x, as.integer = TRUE)
-  cedsmissing <- setdiff(xyears, cedsyears)
-  if (length(cedsmissing) == 1 && cedsmissing > max(cedsyears)) {
-    cedsyears <- c(intersect(cedsyears, xyears), max(cedsyears))
-    ceds <- ceds[, cedsyears, ]
-    getYears(ceds) <- xyears
-  } else if (length(cedsmissing) > 1) {
-    stop("CEDS data not available for ", paste(cedsmissing, collapse = ", "))
-  }
+  ceds <- ceds[, getYears(x), ]
 
-  return(list(x           = x,
-              weight      = ceds,
-              unit        = "US$2005/t CO2",
-              description = "CO2 prices in 2010, 2015 and 2020"))
+  return(list(
+    x = x,
+    weight = ceds,
+    unit = "US$2005/t CO2",
+    description = "CO2 prices in 2010, 2015 and 2020"
+  ))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.182.5**
+R package **mrremind**, version **0.182.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.182.5, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.182.6, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.182.5},
+  note = {R package version 0.182.6},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This fixes

```
Run calcOutput(type = "CO2Prices", file = "pm_taxCO2eqHist.cs4r", round = 2)
~ Run readSource(type = "ExpertGuess", subtype = "co2prices")
~~  - loading cache convertExpertGuess-Fed79ca0f-def4342f.rds
~ Exit readSource(type = "ExpertGuess", subtype = "co2prices") in 0.14 seconds
~ Run calcOutput(type = "Emissions", aggregate = FALSE, datasource = "CEDS2024")
~~ Run readSource(type = "CEDS2024")
~~~  - writing cache readCEDS2024-Fdb5a21cd.rds
~~~ NOTE:  - toolCountryFill set missing values for IMPORTANT countries to 0:
~~~  --- Palestine, State of (PSE) 
~~~  - writing cache convertCEDS2024-Fdb5a21cd.rds
~~ Exit readSource(type = "CEDS2024") in 159.06 seconds
~~  - writing cache calcEmissions-Fbe6dd217-f93a72b5.rds
~ Exit calcOutput(type = "Emissions", aggregate = FALSE, datasource = "CEDS2024") in 271.86 seconds
~ ERROR: 
~ Number of years disagree between data and weight of function "mrremind:::calcCO2Prices()"!
```