### PR TITLE
Add OAE capacity factors

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '36547952'
+ValidationKey: '36667520'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.183.4
+version: 0.184.0
 date-released: '2024-07-24'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.183.4
+Version: 0.184.0
 Date: 2024-07-24
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/readREMIND_11Regi.R
+++ b/R/readREMIND_11Regi.R
@@ -29,12 +29,8 @@ readREMIND_11Regi <- function(subtype) {
       getNames(x) <- "peoil"
       x
     },
-    "deltacapoffset"       = read.csv("p_adj_deltacapoffset.csv", sep = ";")    %>% as.magpie(datacol = 2),
-    "capacityFactorGlobal" = {
-      x <- read.csv("f_cf-global_REMIND_3.3.4.csv", sep = ";")
-      x[x$Tech == "rockgrind", "Tech"] <- "weathering"
-      as.magpie(x, datacol = 2)
-    },
+    "deltacapoffset"       = read.csv("p_adj_deltacapoffset.csv", sep = ";")     %>% as.magpie(datacol = 2),
+    "capacityFactorGlobal" = read.csv("f_cf-global_REMIND_3.3.5.csv", sep = ";") %>% as.magpie(x, datacol = 2),
     "capacityFactorRules"  = read.csv("f_cf-rules.csv", sep = ";")               %>% as.magpie(datacol = 4),
     "storageFactor"        = read.csv("storageFactor.csv", sep = ";")            %>% as.magpie(datacol = 2),
     "residuesShare"        = read.csv("residuesShare.csv", row.names = 1)        %>% as.magpie(datacol = 4),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.183.4**
+R package **mrremind**, version **0.184.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.183.4, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.184.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.183.4},
+  note = {R package version 0.184.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This PR adds capacity factors of OAE (ocean alkalinity enhancement) technologies. To be merged after [REMIND#1741](https://github.com/remindmodel/remind/pull/1741). The new source file can be found here: `/p/projects/rd3mod/inputdata/sources/REMIND_11Regi/f_cf-global_REMIND_3.3.5.csv`.

Changes in `f_cf-global_REMIND_3.3.5.csv` from the previous `f_cf-global_REMIND_3.3.4.csv`:
+**oae_ng;0.8**
+**oae_el;0.8**
~~rockgrind~~**weathering**;0.69