### PR TITLE
update IEA Energy Balances

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '37361999'
+ValidationKey: '37383840'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.187.1
-date-released: '2024-09-03'
+version: 0.187.1.9001
+date-released: '2024-09-04'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.187.1.9001
+version: 0.187.2
 date-released: '2024-09-04'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.187.1.9001
+Version: 0.187.2
 Date: 2024-09-04
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.187.1
-Date: 2024-09-03
+Version: 0.187.1.9001
+Date: 2024-09-04
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFE.R
+++ b/R/calcFE.R
@@ -26,7 +26,7 @@ calcFE <- function(source = "IEA", scenario_proj = "SSP2", ieaVersion = "default
     colnames(map) <- gsub("io", "names_in", colnames(map))
 
     # Give description
-    ieaYear <- if (ieaVersion == "default") 2022 else 2023
+    ieaYear <- if (ieaVersion == "default") 2022 else 2024
     descript <- paste0("IEA Final Energy Data based on ", ieaYear, " version of IEA Energy Balances")
 
     #------ PROCESS DATA ------------------------------------------

--- a/R/calcIO.R
+++ b/R/calcIO.R
@@ -97,7 +97,7 @@ calcIO <- function(subtype = c("input", "output", "output_biomass", "trade",
   }
 
   ieaSubtype <- if (ieaVersion == "default") "EnergyBalances" else "EnergyBalances-latest"
-  ieaYear <- if (ieaVersion == "default") 2022 else 2023
+  ieaYear <- if (ieaVersion == "default") 2022 else 2024
 
   # read in data and convert from ktoe to EJ
   data <- readSource("IEA", subtype = ieaSubtype) * 4.1868e-5

--- a/R/calcPE.R
+++ b/R/calcPE.R
@@ -45,7 +45,7 @@ calcPE <- function(subtype = "IEA", ieaVersion = "default") {
     x <- mbind(x, setNames(dimSums(x[, , "PE|Gas", pmatch = TRUE], dim = 3), "PE|Gas (EJ/yr)"))
     x <- mbind(x, setNames(dimSums(x[, , "PE|Biomass", pmatch = TRUE], dim = 3), "PE|Biomass (EJ/yr)"))
 
-    ieaYear <- if (ieaVersion == "default") 2022 else 2023
+    ieaYear <- if (ieaVersion == "default") 2022 else 2024
 
     return(list(x = x, weight = NULL, unit = "EJ",
                 description = paste0("IEA Primary Energy Data based on ", ieaYear,

--- a/R/calcTrade.R
+++ b/R/calcTrade.R
@@ -23,6 +23,6 @@ calcTrade <- function() {
 
   return(list(
     x = x, weight = NULL, unit = "EJ",
-    description = "IEA Final Energy Data based on 2023 version of IEA Energy Balances"
+    description = "IEA Final Energy Data based on 2024 version of IEA Energy Balances"
   ))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.187.1.9001**
+R package **mrremind**, version **0.187.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.187.1.9001, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.187.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.187.1.9001},
+  note = {R package version 0.187.2},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.187.1**
+R package **mrremind**, version **0.187.1.9001**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.187.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.187.1.9001, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.187.1},
+  note = {R package version 0.187.1.9001},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Update reference data to July 2024 data. This gives us an additional year (2022).
See comparison to July 2023 here: https://cloud.pik-potsdam.de/index.php/f/22077519
