### PR TITLE
NDC update 2024-08-31

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '37405683'
+ValidationKey: '37433150'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.187.3
-date-released: '2024-09-05'
+version: 0.187.4
+date-released: '2024-09-09'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.187.3
-Date: 2024-09-05
+Version: 0.187.4
+Date: 2024-09-09
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCapTarget.R
+++ b/R/calcCapTarget.R
@@ -32,7 +32,7 @@ calcCapTarget <- function(sources) {
       "2023_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2023_cond"),
       "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2023_uncond"),
       "2024_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2024_cond"),
-      "2024_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2024_uncond"),
+      "2024_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2024_uncond")
     )
 
     listYears   <- lapply(listCapacitiesNDC, getItems, dim = "year") %>% unlist() %>% unique() %>% sort()

--- a/R/calcCapTarget.R
+++ b/R/calcCapTarget.R
@@ -30,7 +30,9 @@ calcCapTarget <- function(sources) {
       "2022_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2022_cond"),
       "2022_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2022_uncond"),
       "2023_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2023_cond"),
-      "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2023_uncond")
+      "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2023_uncond"),
+      "2024_cond"   = readSource("UNFCCC_NDC", subtype = "Capacity_2024_cond"),
+      "2024_uncond" = readSource("UNFCCC_NDC", subtype = "Capacity_2024_uncond"),
     )
 
     listYears   <- lapply(listCapacitiesNDC, getItems, dim = "year") %>% unlist() %>% unique() %>% sort()

--- a/R/calcEmiTarget.R
+++ b/R/calcEmiTarget.R
@@ -46,7 +46,9 @@ calcEmiTarget <- function(sources, subtype) {
       "2022_cond"   = readSource("UNFCCC_NDC", subtype = "Emissions_2022_cond"),
       "2022_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2022_uncond"),
       "2023_cond"   = readSource("UNFCCC_NDC", subtype = "Emissions_2023_cond"),
-      "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2023_uncond")
+      "2023_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2023_uncond"),
+      "2024_cond"   = readSource("UNFCCC_NDC", subtype = "Emissions_2024_cond"),
+      "2024_uncond" = readSource("UNFCCC_NDC", subtype = "Emissions_2024_uncond")
     )
 
     listYears   <- lapply(listGhgfactors, getItems, dim = "year") %>% unlist() %>% unique() %>% sort()

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -17,9 +17,11 @@ readUNFCCC_NDC <- function(subtype) {
     NDCfile <- "NDC_2021.xlsx"
   } else if (grepl("2022", subtype, fixed = TRUE)) {
     NDCfile <- "NDC_2022-12-31.xlsx"
-  } else {
+  } else if (grepl("2023", subtype, fixed = TRUE)) {
     NDCfile <- "NDC_2023-11-29.xlsx"
-    if (!grepl("2023", subtype, fixed = TRUE)) {
+  } else {
+    NDCfile <- "NDC_2024-08-31.xlsx"
+    if (!grepl("2024", subtype, fixed = TRUE)) {
       warning("\nNo data for year in ", subtype, " available. Choose default: ", NDCfile)
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.187.3**
+R package **mrremind**, version **0.187.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.187.3, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.187.4, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.187.3},
+  note = {R package version 0.187.4},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Only Namibia, Panama and Madagascar have published new NDCs hitherto. Namibia and Madagascar did not change anything of substance, Panama leads to this absolutely minor change:

The 2005 GHG emission share of countries with quantifyable emissions under NDC has changed this way:
LAM 2023: 0.7654 -> 0.786

The Multiplier for target year emissions vs 2005 emissions has changed this way:
LAM 2023: 0.7519 -> 0.7522
