### PR TITLE
Remove ECEMF scenarios and fix demScen names

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '38171350'
+ValidationKey: '38191335'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.191.0
+version: 0.191.1
 date-released: '2024-09-19'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.191.0
+Version: 0.191.1
 Date: 2024-09-19
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/readEDGETransport.R
+++ b/R/readEDGETransport.R
@@ -46,12 +46,6 @@ readEDGETransport <- function(subtype) {
       'SDP_MC',        'Mix4',                    TRUE,       'default',
       'SDP_RC',        'Mix3',                    TRUE,       'default',
       'SSP2',          'HydrHype4',               TRUE,       'default',
-      'SSP2',          'ECEMF_HighEl_HighEff',    TRUE,       'default',
-      'SSP2',          'ECEMF_HighEl_LifestCha',  TRUE,       'SSP2_demRedStrong',
-      'SSP2',          'ECEMF_HighEl_ModEff',     TRUE,       'default',
-      'SSP2',          'ECEMF_HighH2_HighEff',    TRUE,       'default',
-      'SSP2',          'ECEMF_HighH2_LifestCha',  TRUE,       'SSP2_demRedStrong',
-      'SSP2',          'ECEMF_HighH2_ModEff',     TRUE,       'default',
       'SSP2',          'NAV_act',                 FALSE,      'SSP2_demRedStrong',
       'SSP2',          'NAV_tec',                 FALSE,      'default',
       'SSP2',          'NAV_ele',                 TRUE,       'default',
@@ -98,17 +92,17 @@ readEDGETransport <- function(subtype) {
   #############################################################
   translateEdgeTransportDemScentoREMIND <- function(dt) {
     dt[DEM_scenario == "gdp_SSP2_demDiffer" & EDGE_scenario == "Mix4ICEban", DEM_scenario := "gdp_SSP2_demDiffer_IKEA"]
-    dt[DEM_scenario == "gdp_SSP2EU" & EDGE_scenario == "NAV_ele", DEM_scenario := "gdp_SSP2EU_NAV_ele"]
-    dt[DEM_scenario == "gdp_SSP2EU" & EDGE_scenario == "NAV_tec", DEM_scenario := "gdp_SSP2EU_NAV_tec"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "NAV_act", DEM_scenario := "gdp_SSP2EU_NAV_act"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "NAV_all", DEM_scenario := "gdp_SSP2EU_NAV_all"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "NAV_lce", DEM_scenario := "gdp_SSP2EU_NAV_lce"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedWeak" & EDGE_scenario == "CAMP_lscWeak", DEM_scenario := "gdp_SSP2EU_CAMP_weak"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "CAMP_lscStrong", DEM_scenario := "gdp_SSP2EU_CAMP_strong"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "Mix1", DEM_scenario := "gdp_SSP2_lowEn"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "Mix2", DEM_scenario := "gdp_SSP2_lowEn"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "Mix3ICEban", DEM_scenario := "gdp_SSP2_lowEn"]
-    dt[DEM_scenario == "gdp_SSP2EU_demRedStrong" & EDGE_scenario == "Mix4ICEban", DEM_scenario := "gdp_SSP2_lowEn"]
+    dt[DEM_scenario == "gdp_SSP2" & EDGE_scenario == "NAV_ele", DEM_scenario := "gdp_SSP2EU_NAV_ele"]
+    dt[DEM_scenario == "gdp_SSP2" & EDGE_scenario == "NAV_tec", DEM_scenario := "gdp_SSP2EU_NAV_tec"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "NAV_act", DEM_scenario := "gdp_SSP2EU_NAV_act"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "NAV_all", DEM_scenario := "gdp_SSP2EU_NAV_all"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "NAV_lce", DEM_scenario := "gdp_SSP2EU_NAV_lce"]
+    dt[DEM_scenario == "gdp_SSP2_demRedWeak" & EDGE_scenario == "CAMP_lscWeak", DEM_scenario := "gdp_SSP2EU_CAMP_weak"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "CAMP_lscStrong", DEM_scenario := "gdp_SSP2EU_CAMP_strong"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "Mix1", DEM_scenario := "gdp_SSP2_lowEn"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "Mix2", DEM_scenario := "gdp_SSP2_lowEn"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "Mix3ICEban", DEM_scenario := "gdp_SSP2_lowEn"]
+    dt[DEM_scenario == "gdp_SSP2_demRedStrong" & EDGE_scenario == "Mix4ICEban", DEM_scenario := "gdp_SSP2_lowEn"]
     return(dt)
   }
   EdgeTransportSAdata <- lapply(EdgeTransportSAdata, translateEdgeTransportDemScentoREMIND)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.191.0**
+R package **mrremind**, version **0.191.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.191.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.191.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.191.0},
+  note = {R package version 0.191.1},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
This PR

1. Removes the ECEMF scenarios from the REMIND input data generation. So far they are not used in REMIND (only in EDGE-T standalone) and they have no associated REMIND demand scenario that is coordinated with other sectors. 
2. Corrects the edge-t internal demand scenario names to SSP2 instead of SSP2EU

its connected to [PR1834](https://github.com/remindmodel/remind/pull/1834) in remind