### PR TITLE
update EDGAR to 2024 publication

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '38400790'
+ValidationKey: '38422702'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.192.1
-date-released: '2024-09-24'
+version: 0.192.2
+date-released: '2024-09-25'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.192.1
-Date: 2024-09-24
+Version: 0.192.2
+Date: 2024-09-25
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcEmissions.R
+++ b/R/calcEmissions.R
@@ -2,7 +2,7 @@
 #'
 #' @return magpie object with historical emissions
 #' @param datasource "CEDS16", "CEDS2REMIND", "CEDS2024", "EDGAR", "EDGAR6",
-#'        "EDGAR8" "LIMITS", "ECLIPSE", "GFED", "CDIAC"
+#'        "EDGARghg" "LIMITS", "ECLIPSE", "GFED", "CDIAC"
 #'
 #' @author Steve Smith, Pascal Weigmann
 #'
@@ -856,9 +856,10 @@ calcEmissions <- function(datasource = "CEDS16") {
     tmp <- emi
     description <- "historic emissions from 1970-2018"
 
-    ## ---- EDGAR 8 ----
-  } else if (datasource == "EDGAR8") {
-    emi <- readSource("EDGAR8")
+    ## ---- EDGAR GHG ----
+    # previous version: "EDGAR8"
+  } else if (datasource == "EDGARghg") {
+    emi <- readSource("EDGARghg")
     emi[is.na(emi)] <- 0
 
     # map variables
@@ -934,7 +935,7 @@ calcEmissions <- function(datasource = "CEDS16") {
 
     tmp <- emi
 
-    description <- "historic emissions from 1970-2022"
+    description <- "historic emissions from 1970-2023"
 
     ## ---- LIMITS ----
   } else if (datasource == "LIMITS") {

--- a/R/calcEmissionsTe.R
+++ b/R/calcEmissionsTe.R
@@ -1,15 +1,20 @@
 
 calcEmissionsTe <- function() {
-  
-  x <- calcOutput("Emissions",datasource="CDIAC",aggregate=FALSE)[,2010,]
-  x <- x[,,"Emissions|CO2|Fossil Fuels and Industry (Mt/yr)"] - x[,,"Emissions|CO2|Industrial Processes|Cement (Mt/yr)"] + x[,,"Emissions|CO2|Energy|Bunkers (Mt/yr)"]
-  
+
+  x <- calcOutput("Emissions", datasource = "CDIAC", aggregate = FALSE)[, 2010, ]
+  x <- x[, , "Emissions|CO2|Fossil Fuels and Industry (Mt/yr)"] -
+       x[, , "Emissions|CO2|Industrial Processes|Cement (Mt/yr)"] +
+       x[, , "Emissions|CO2|Energy|Bunkers (Mt/yr)"]
+
   # convert from Mt CO2 into GtC
-  x <- x / 44 * 12 / 1000
-  
+  x <- x/44*12/1000
+
   # reduce dimension
   x <- collapseNames(x)
-  
-  return(list(x=x,weight=NULL,unit="GtC",
-              description="CO2 emissions (Fossil Fuels and Industry) from CDIAC"))
+
+  return(list(x = x,
+              weight = NULL,
+              unit = "GtC",
+              description = "CO2 emissions (Fossil Fuels and Industry) from CDIAC")
+         )
 }

--- a/R/fullVALIDATIONREMIND.R
+++ b/R/fullVALIDATIONREMIND.R
@@ -87,21 +87,21 @@ fullVALIDATIONREMIND <- function(rev = 0) {
     writeArgs = list(scenario = "historical", model = "EDGAR6")
   )
 
-  # EDGAR8 Emissions----
-
-  edg8 <- calcOutput(
-    type = "Emissions", datasource = "EDGAR8",
+  # EDGAR GHG Emissions----
+  # does not contain as many gases as EDGAR6
+  edgar <- calcOutput(
+    type = "Emissions", datasource = "EDGARghg",
     aggregate = columnsForAggregation, warnNA = FALSE,
     try = FALSE, years = years
   )
 
   # write all regions of non-bunker variables to report
-  non_bunk <- edg8[, , "International", pmatch = TRUE, invert = TRUE]
+  non_bunk <- edgar[, , "International", pmatch = TRUE, invert = TRUE]
   write.report(non_bunk, file = valfile, append = TRUE,
                scenario = "historical", model = "EDGAR8")
 
   # write only global values of bunker variables
-  bunkers <- edg8["GLO", , "International", pmatch = TRUE]
+  bunkers <- edgar["GLO", , "International", pmatch = TRUE]
   write.report(bunkers, file = valfile, append = TRUE,
                scenario = "historical", model = "EDGAR8")
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.192.1**
+R package **mrremind**, version **0.192.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.192.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.192.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.192.1},
+  note = {R package version 0.192.2},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/man/calcEmissions.Rd
+++ b/man/calcEmissions.Rd
@@ -8,7 +8,7 @@ calcEmissions(datasource = "CEDS16")
 }
 \arguments{
 \item{datasource}{"CEDS16", "CEDS2REMIND", "CEDS2024", "EDGAR", "EDGAR6",
-"EDGAR8" "LIMITS", "ECLIPSE", "GFED", "CDIAC"}
+"EDGARghg" "LIMITS", "ECLIPSE", "GFED", "CDIAC"}
 }
 \value{
 magpie object with historical emissions


### PR DESCRIPTION
The EDGAR 2023 publication went by the name "EDGAR8", the 2024 version seems to not use a number anymore. Further EDGAR GHG publications are now named "EDGARghg" as opposed to the older EDGAR versions which contain more gases (EDGAR6) or land-use focus (EDGAR_LU, EDGARfood).