### PR TITLE
Fix bugs in convertEdgeBuildings and readEdgeBuildings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '38773566'
+ValidationKey: '38795512'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.193.8
-date-released: '2024-10-11'
+version: 0.193.9
+date-released: '2024-10-12'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.193.8
-Date: 2024-10-11
+Version: 0.193.9
+Date: 2024-10-12
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/convertEdgeBuildings.R
+++ b/R/convertEdgeBuildings.R
@@ -177,6 +177,7 @@ convertEdgeBuildings <- function(x, subtype = "FE") {
     # duplicate SSP2 for SSP2_lowEn an SSP2EU for Navigate and Campaigners scenarios
     wp <- duplScens(wp)
 
+    x <- time_interpolate(x, interpolated_year = rem_years_hist, extrapolation_type = "constant")
     x <- toolAggregate(x[, rem_years_hist, ], mappingfile, weight = wp,
                        from = region_col, to = iso_col)
     result <- x

--- a/R/readEdgeBuildings.R
+++ b/R/readEdgeBuildings.R
@@ -14,7 +14,8 @@ readEdgeBuildings <- function(subtype = c("FE", "Floorspace")) {
   scenarios <- list(
     SSPs  = paste0("SSP", 1:5),
     SSP2s = paste0("SSP2", c("EU", "_lowEn")),
-    SDPs  = paste0("SDP", c("", "_EI", "_MC", "_RC")))
+    SDPs  = paste0("SDP", c("", "_EI", "_MC", "_RC"))
+  )
 
   data <- read.csv(file.path(ver, "EDGE_buildings.csv"))
   data <- as.magpie(data)
@@ -31,10 +32,10 @@ readEdgeBuildings <- function(subtype = c("FE", "Floorspace")) {
       # Extract RCP scenarios from the scenario column if any are present
       if (length(rcpScens) >= 1) {
         dataRcp <- do.call(mbind, lapply(rcpScens, function(rcp) {
-            tmp <- mselect(data, scenario = grep(rcp, getItems(data, dim = "scenario"), value = TRUE))
-            getNames(tmp, dim = "rcp") <- if (grepl("rcp\\d$", rcp)) paste0(rcp, "0") else gsub("_", "", rcp)
-            getNames(tmp, dim = "scenario") <- gsub("_rcp\\d_*\\d*", "", getNames(tmp, dim = "scenario"))
-            return(tmp)
+          tmp <- mselect(data, scenario = grep(rcp, getItems(data, dim = "scenario"), value = TRUE))
+          getNames(tmp, dim = "rcp") <- if (grepl("rcp\\d$", rcp)) paste0(rcp, "0") else gsub("_", "", rcp)
+          getNames(tmp, dim = "scenario") <- gsub("_rcp\\d_*\\d*", "", getNames(tmp, dim = "scenario"))
+          return(tmp)
         }))
         if (!all(grepl("_rcp\\d_*\\d*", getItems(data, dim = "scenario")))) {
           dataNoRcp <- mselect(data, scenario = grep("_rcp\\d_*\\d*", getItems(data, dim = "scenario"),
@@ -44,12 +45,13 @@ readEdgeBuildings <- function(subtype = c("FE", "Floorspace")) {
           data <- dataRcp
         }
       }
-      # getNames(data) <- gsub("NoC", "fixed", getNames(data))
       getSets(data) <- c("region", "year", "scenario", "rcp", "item")
     },
     Floorspace = {
       data <- mselect(data, variable = grep("^floorspace", getItems(data, dim = "variable"), value = TRUE))
       getNames(data, dim = "scenario") <- gsub("_rcp.*$", "", getNames(data, dim = "scenario"))
+      getNames(data, dim = "variable") <- gsub("^floorspace_(\\w+)$", "\\1", getNames(data, dim = "variable"))
+      getNames(data, dim = "variable") <- gsub("^floorspace$", "buildings", getNames(data, dim = "variable"))
       data <- collapseNames(data)
       getSets(data) <- c("region", "year", "scenario", "variable")
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.193.8**
+R package **mrremind**, version **0.193.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.193.8, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.193.9, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.193.8},
+  note = {R package version 0.193.9},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Fix bugs in buildings computations introduced with the new EDGE buildings data in PR #576 :
- fix non-matching time dimension in convert Edge buildings
- adjust readEdgeBuildings, subtype floorspace, to new variable naming in EDGE buildings output
- fix some lintr warnings