### PR TITLE
Update biomass supplycurves

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '39507048'
+ValidationKey: '39529055'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.197.2
-date-released: '2024-11-07'
+version: 0.197.3
+date-released: '2024-11-08'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.197.2
-Date: 2024-11-07
+Version: 0.197.3
+Date: 2024-11-08
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcBiomassPrices.R
+++ b/R/calcBiomassPrices.R
@@ -4,16 +4,17 @@
 calcBiomassPrices <- function() {
 
   x <- readSource("MAgPIE", subtype = "supplyCurve_magpie_40")
+  
+  # add supply curves for SSP1-PkBudg1000 copying SSP1-PkBudg650
+  tmp <- x[, , "SSP1-SSP1-PkBudg650"]
+  getNames(tmp) <- gsub("SSP1-SSP1-PkBudg650", "SSP1-SSP1-PkBudg1000", getNames(tmp))
+  x <- mbind(x, tmp)
 
   # rename the rcp-scenarios to cm_rcp_scen switches used in REMIND
-  getNames(x) <- gsub("NDC-nocc_hist-PkBudg650",  "rcp20", getNames(x))
-  getNames(x) <- gsub("NDC-nocc_hist-PkBudg1050", "rcp26", getNames(x))
-  getNames(x) <- gsub("NDC-nocc_hist-NDC",        "rcp45", getNames(x))
-  getNames(x) <- gsub("NPI-nocc_hist-Base",       "none", getNames(x))
-
-  # rename SSP-scenarios to cm_LU_emi_scen switches used in REMIND
-  getNames(x) <- gsub("SSP2EU", "SSP2", getNames(x))
-  getNames(x) <- gsub("SDP-MC", "SDP",  getNames(x))
+  # eample: SSP2-SSP2_lowEn-PkBudg1000 -> SSP2-rcp26
+  getNames(x) <- gsub("SSP[1-5](_lowEn|)-PkBudg650",  "rcp20", getNames(x))
+  getNames(x) <- gsub("SSP[1-5](_lowEn|)-PkBudg1000", "rcp26", getNames(x))
+  getNames(x) <- gsub("SSP[1-5](_lowEn|)-NPi",        "rcp45", getNames(x))
 
   # Introduce new SSP/SDP dimension by replacing "-" with "."
   getNames(x) <- gsub("(SSP[0-9]|SDP)-", "\\1.", getNames(x))
@@ -21,24 +22,10 @@ calcBiomassPrices <- function() {
   getSets(x)["d3.2"] <- "scen2"
   getSets(x)["d3.3"] <- "char"
 
-  # add supply curves for SSP3 using the curves from SSP2
-  tmp <- x[, , "SSP2"]
-  getNames(tmp) <- gsub("SSP2", "SSP3", getNames(tmp))
-  x <- mbind(x, tmp)
-
   # if fit coefficients of a country are NA for all years (there is no supplycurve at all for this country)
   # generate artificial supplycurve with VERY high prices
   x[, , "a"][is.na(x[, , "a"])] <- 1
   x[, , "b"][is.na(x[, , "b"])] <- 0.1
-
-  # apply conversion from US$2005 to US$2017 to "a" and "b", so that the price
-  # calculated with these coefficients will be in US$2017
-  x <- GDPuc::toolConvertGDP(
-    gdp = x,
-    unit_in = "constant 2005 US$MER",
-    unit_out = mrdrivers::toolGetUnitDollar(),
-    replace_NAs = "with_USA"
-  )
 
   return(list(x           = x,
               weight      = calcOutput("FAOLand", aggregate = FALSE)[, , "6610", pmatch = TRUE][, "y2010", ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.197.2**
+R package **mrremind**, version **0.197.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.197.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.197.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.197.2},
+  note = {R package version 0.197.3},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Read new biomass supplycurves from MAgPIE magpie_4.8.1 including SSP3 and unit shift (US$2017). Other input data from MAgPIE (emissions, costs) remain unchanged.