### PR TITLE
Replace biomass supply curves for SSP1 because they were configured i…

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40098000'
+ValidationKey: '40118049'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.200.0
+version: 0.200.1
 date-released: '2024-11-22'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.200.0
+Version: 0.200.1
 Date: 2024-11-22
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcBiomassPrices.R
+++ b/R/calcBiomassPrices.R
@@ -5,9 +5,9 @@ calcBiomassPrices <- function() {
 
   x <- readSource("MAgPIE", subtype = "supplyCurve_magpie_40")
 
-  # add supply curves for SSP1-PkBudg1000 copying SSP1-PkBudg650
-  tmp <- x[, , "SSP1-SSP1-PkBudg650"]
-  getNames(tmp) <- gsub("SSP1-SSP1-PkBudg650", "SSP1-SSP1-PkBudg1000", getNames(tmp))
+  # add supply curves for SDP-MC-SSP1-PkBudg1000 copying SDP-MC-SSP1-PkBudg650
+  tmp <- x[, , "SDP-MC-SSP1-PkBudg650"] 
+  getNames(tmp) <- gsub("SDP-MC-SSP1-PkBudg650", "SDP-MC-SSP1-PkBudg1000", getNames(tmp))
   x <- mbind(x, tmp)
 
   # create cm_LU_emi_scen names (as used in REMIND) from emulatpr scenario names
@@ -15,7 +15,7 @@ calcBiomassPrices <- function() {
   # - the first SSP-scenario ("SSP2") refers to the MAgPIE scenario selected for the emulator runs
   # - the second SSP-scenario ("SSP2_lowen") refers to the REMIND scenario the GHG prices were taken from
   # They need to be combined into a new scenario name that is used in REMIND's cm_LU_emi_scen
-  getNames(x) <- gsub("SSP1-SSP1-",       "SSP1-",       getNames(x))
+  getNames(x) <- gsub("SDP-MC-SSP1-",     "SSP1-",       getNames(x))
   getNames(x) <- gsub("SSP2-SSP2-",       "SSP2-",       getNames(x))
   getNames(x) <- gsub("SSP2-SSP2_lowEn-", "SSP2_lowEn-", getNames(x))
   getNames(x) <- gsub("SSP3-SSP2-",       "SSP3-",       getNames(x))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.200.0**
+R package **mrremind**, version **0.200.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.200.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.200.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.200.0},
+  note = {R package version 0.200.1},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Replace biomass supply curves for SSP1 because they were configured incorrectly, now using SDP-MC|SSP1-POP-GDP scenario instead of SSP1 in MAgPIE.