### PR TITLE
Update expert guesses 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40098000'
+ValidationKey: '40118049'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.200.0
+version: 0.200.1
 date-released: '2024-11-22'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.200.0
+Version: 0.200.1
 Date: 2024-11-22
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcDiffInvestCosts.R
+++ b/R/calcDiffInvestCosts.R
@@ -146,8 +146,8 @@ calcDiffInvestCosts <- function(subtype) {
     # the lowest prices realized in some auctions
     x_adj["MEA", , ] <- 800
     # REF: Very different costs in IRENA (2300) and REN21 (1300) -
-    # but unlikely to have higher capital costs than severly space-constrained Japan
-    x_adj["REF", , ] <- 1400
+    # but unlikely to have higher capital costs than severely space-constrained Japan
+    x_adj["REF", , ] <- 1100
     # SSA: IRENA states prices of ~1600$/W, but very likely that prices are currently decreasing through learning
     # from the low prices in North African countries.
     x_adj["SSA", , ] <- 1100

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -41,7 +41,7 @@ readExpertGuess <- function(subtype) {
   } else if (subtype == "co2prices") {
     a <- read.csv("co2prices-2024-11.csv", sep = ";")
   } else if (subtype == "costsTradePeFinancial") {
-    a <- read.csv("pm_costsTradePeFinancial.csv",
+    a <- read.csv("pm_costsTradePeFinancial_v1.1.csv",
       sep = ";",
       skip = 2
     )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.200.0**
+R package **mrremind**, version **0.200.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind)  [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.200.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.200.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.200.0},
+  note = {R package version 0.200.1},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```


### PR DESCRIPTION
Increase gas import costs to Japan by 2$/GJ to better match historic gas prices and prevent counterfactual strong build-out of gas power plants after 2020. Value set by Robert Pietzcker in exchange with Nico Bauer