### PR TITLE
Update Mapping_Ember.csv - only fossil emissions should be counted

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '40547323'
+ValidationKey: '40729920'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.202.1
-date-released: '2024-12-06'
+version: 0.203.0
+date-released: '2024-12-07'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.202.1
-Date: 2024-12-06
+Version: 0.203.0
+Date: 2024-12-07
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.202.1**
+R package **mrremind**, version **0.203.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.202.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2024). _mrremind: MadRat REMIND Input Data Package_. R package version 0.203.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
   year = {2024},
-  note = {R package version 0.202.1},
+  note = {R package version 0.203.0},
   url = {https://github.com/pik-piam/mrremind},
 }
 ```

--- a/inst/extdata/reportingVariables/Mapping_Ember.csv
+++ b/inst/extdata/reportingVariables/Mapping_Ember.csv
@@ -49,7 +49,7 @@ Electricity generation|Fuel|Wind;TWh;SE|Electricity|Wind;EJ/yr;;0.0036
 Electricity generation|Total|Total Generation;TWh;SE|Electricity;EJ/yr;;0.0036
 Electricity imports|Electricity imports|Net Imports;TWh;;;;
 Power sector emissions|Aggregate fuel|Clean;mtCO2;;;actually is CO2eq;
-Power sector emissions|Aggregate fuel|Fossil;mtCO2;;;;
+Power sector emissions|Aggregate fuel|Fossil;mtCO2;Emi|CO2|Energy|Supply|Electricity w/ couple prod;Mt CO2/yr;;1
 Power sector emissions|Aggregate fuel|Gas and Other Fossil;mtCO2;;;;
 Power sector emissions|Aggregate fuel|Hydro, Bioenergy and Other Renewables;mtCO2;;;;
 Power sector emissions|Aggregate fuel|Renewables;mtCO2;;;;
@@ -64,4 +64,4 @@ Power sector emissions|Fuel|Other Fossil;mtCO2;;;;
 Power sector emissions|Fuel|Other Renewables;mtCO2;;;;
 Power sector emissions|Fuel|Solar;mtCO2;;;;
 Power sector emissions|Fuel|Wind;mtCO2;;;;
-Power sector emissions|Total|Total emissions;mtCO2;Emi|CO2|Energy|Supply|Electricity w/ couple prod;Mt CO2eq/yr;;1
+Power sector emissions|Total|Total emissions;mtCO2;;;;


### PR DESCRIPTION
EMBER reports life cycle emissions, thus also emissions for renewables/nuclear etc. 

in REMIND, we only have fuel emissions from use - to get as close to this as possible, only "Fossil" emissions should be counted for Emi|CO2|Energy|Supply|Electricity.

Also, while EMBER does count other GHG emissions, it only makes sense to use "Mt CO2/yr" as unit for a variable called "Emi|CO2|xxx"