### PR TITLE
Adapt SSP3 capital intensities

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '41241096'
+ValidationKey: '41408060'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.205.2
-date-released: '2025-01-10'
+version: 0.206.0
+date-released: '2025-01-13'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.205.2
-Date: 2025-01-10
+Version: 0.206.0
+Date: 2025-01-13
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCapital.R
+++ b/R/calcCapital.R
@@ -25,7 +25,7 @@ calcCapital <- function() {
   # that reference, for the different GDP scenarios. The convergence assumptions should follow the SSP narratives.
   # Convergence starts after 2010.
   kIntRef <- kIntPWT["JPN", 2010, ] %>% as.numeric()
-  convTime <- c("SSP1" = 150, "SSP2" = 250, "SSP3" = 500, "SSP4" = 300, "SSP5" = 150,
+  convTime <- c("SSP1" = 150, "SSP2" = 250, "SSP3" = 150, "SSP4" = 300, "SSP5" = 150,
                 "SDP" = 150, "SDP_EI" = 150, "SDP_RC" = 150, "SDP_MC" = 150, "SSP2EU" = 250)
 
   # Create kInt magpie object with the same dimension as gdp, and assign the PWT capital intensities for the
@@ -34,10 +34,23 @@ calcCapital <- function() {
   hy <- c(1995, 2000, 2005, 2010)
   kInt[, hy, ] <- kIntPWT[, hy, ]
   # For future years (after 2010), linearly converge towards kIntRef
+  ## Special convergence for SSP3: use a 25% higher reference value, and let JPN reach this value by 2060.
   fy <- setdiff(getYears(gdp, as.integer = TRUE), hy)
   for (t in fy) {
     for (s in getNames(kInt)) {
-      kInt[, t, s] <-  kInt[, 2010, s] + (kIntRef - kInt[, 2010, s]) * (t - 2010) / convTime[s]
+      # Special case for SSP3
+      if (s == "SSP3") {
+        kInt[, t, s] <-  kInt[, 2010, s] + (kIntRef * 1.25 - kInt[, 2010, s]) * (t - 2010) / convTime[s]
+        if (t <= 2060) {
+          kInt["JPN", t, s] <-  kInt["JPN", 2010, s] + (kIntRef * 1.25 - kInt["JPN", 2010, s]) * (t - 2010) / 50
+        } else {
+          kInt["JPN", t, s] <-  kInt["JPN", 2060, s]
+        }
+      # For all other sceanarios
+      } else {
+        kInt[, t, s] <-  kInt[, 2010, s] + (kIntRef - kInt[, 2010, s]) * (t - 2010) / convTime[s]
+      }
+
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.205.2**
+R package **mrremind**, version **0.206.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.205.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.206.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-01-10},
+  date = {2025-01-13},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.205.2},
+  note = {Version: 0.206.0},
 }
 ```


### PR DESCRIPTION
The capital intensities in SSP3 now converge quicker, to a 25% higher reference value. 

Japan (the country from which we take the reference value) converges to this 25% higher value by 2060. Looks now like this: 
![image](https://github.com/user-attachments/assets/bf228d69-1a3e-4065-bcdc-caca16b11080)
