### PR TITLE
New baseline-dependent MACCs in fullREMIND

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42849210'
+ValidationKey: '43050380'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.213.0
+version: 0.214.0
 date-released: '2025-01-29'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.213.0
+Version: 0.214.0
 Date: 2025-01-29
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/fullREMIND.R
+++ b/R/fullREMIND.R
@@ -87,6 +87,8 @@ fullREMIND <- function() {
   calcOutput("MACCbaseN2O",  source = "PBL_2022",                              round = 5, file = "p_macBaseHarmsen2022.cs4r")
   calcOutput("MACCsCH4", source = "ImageMacc",                                  round = 6, file = "p_abatparam_CH4.cs4r")
   calcOutput("MACCsN2O", source = "ImageMacc",                                  round = 6, file = "p_abatparam_N2O.cs4r")
+  calcOutput("MACCsCH4", source = "PBL_MACC_SSP2_2022",                         round = 6, file = "p_abatparam_SSP22022_CH4.cs4r")
+  calcOutput("MACCsN2O", source = "PBL_MACC_SSP2_2022",                         round = 6, file = "p_abatparam_SSP22022_N2O.cs4r")
   calcOutput("FGas",                                                            round = 6, file = "f_emiFgas.cs4r")
   calcOutput("EmiFossilFuelExtr", source = "EDGAR",                             round = 6, file = "p_emiFossilFuelExtr.cs4r")
   calcOutput("EmiFossilFuelExtr", source = "CEDS2024",                          round = 6, file = "p_emiFossilFuelExtr2020.cs4r")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.213.0**
+R package **mrremind**, version **0.214.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.213.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.214.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-01-29},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.213.0},
+  note = {Version: 0.214.0},
 }
 ```

--- a/man/calcMACCbaseN2O.Rd
+++ b/man/calcMACCbaseN2O.Rd
@@ -7,17 +7,21 @@ for transport, adipic acid and nitric acid production}
 \usage{
 calcMACCbaseN2O(source = "PBL_2007")
 }
+\arguments{
+\item{source}{either "PBL_2007" or "PBL_2022"
+If source is PBL_2007, the source of the ultimately the baseline
+scenario of Lucas et al 2007 (http://linkinghub.elsevier.com/retrieve/pii/S1462901106001316)
+
+If source is PBL_2022, the source of the ultimately the baseline
+scenario of Harmsen et al. 2023 (https://doi.org/10.1038/s41467-023-38577-4)}
+}
 \value{
 list of magclass with REMIND input data for
 different sectors for timesteps 2000-2100, in Mt N per year
 }
 \description{
-If source is PBL_2007, the source of the ultimately the baseline
-scenario of Lucas et al 2007 (http://linkinghub.elsevier.com/retrieve/pii/S1462901106001316)
-}
-\details{
-If source is PBL_2022, the source of the ultimately the baseline
-scenario of Harmsen et al. 2023 (https://doi.org/10.1038/s41467-023-38577-4)
+Calculate baseline emissions trajectories
+for transport, adipic acid and nitric acid production
 }
 \author{
 Lavinia Baumstark, Gabriel Abrhahao


### PR DESCRIPTION
This just implements calls to the new source for the MACCs, which are independent of the old ones. More details will follow in a subsequent REMIND PR.

```
calcOutput("MACCsCH4", source = "PBL_MACC_SSP2_2022",                         round = 6, file = "p_abatparam_SSP22022_CH4.cs4r")
  calcOutput("MACCsN2O", source = "PBL_MACC_SSP2_2022",                         round = 6, file = "p_abatparam_SSP22022_N2O.cs4r")
```