### PR TITLE
Add distribution of Exclusive Economic Zone (EEZ) area 

### DIFF
--- a/R/calcEEZdistribution.R
+++ b/R/calcEEZdistribution.R
@@ -1,0 +1,18 @@
+#' Calculate distribution of total EEZ size
+#'
+#' @author Tabea Dorndorf
+#'
+calcEEZdistribution <- function() {
+  x <- readSource("MarineRegionsOrg")
+
+  x[is.na(x)] <- 0
+
+  # calculate the share of each country in the total area
+  x <- x / sum(x)
+
+  return(list(
+    x = x,
+    unit = "fraction",
+    description = "Share in global EEZ area. Source: marineregions.org"
+  ))
+}

--- a/R/convertMarineRegionsOrg.R
+++ b/R/convertMarineRegionsOrg.R
@@ -1,0 +1,10 @@
+#' Convert Exclusive Economic Zone (EEZ) size data
+#'
+#' @param x MAgPIE object to be converted
+#'
+#' @author Tabea Dorndorf
+#'
+convertMarineRegionsOrg <- function(x) {
+  x <- toolCountryFill(x, fill = NA, verbosity = 2)
+  return(x)
+}

--- a/R/fullREMIND.R
+++ b/R/fullREMIND.R
@@ -141,6 +141,7 @@ fullREMIND <- function() {
   calcOutput("PotentialGeothermal",                   round = 3,  file = "f_maxProdGeothermal.cs3r")
   calcOutput("PotentialWeathering",                   round = 3,  file = "f33_maxProdGradeRegiWeathering.cs3r")
   calcOutput("CostsWeathering",                       round = 8,  file = "p33_transportCostsWeathering.cs4r")
+  calcOutput("EEZdistribution",                       round = 4,  file = "p33_EEZdistribution.cs3r")
   calcOutput("CostsTrade",                            round = 5,  file = "pm_costsPEtradeMp.cs4r")
   calcOutput("CostsTradePeFinancial",                 round = 5,  file = "pm_costsTradePeFinancial.cs3r")
   calcOutput("ShareCHP",                              round = 3,  file = "f32_shCHP.cs4r")

--- a/R/readMarineRegionsOrg.R
+++ b/R/readMarineRegionsOrg.R
@@ -1,0 +1,46 @@
+#' Load Exclusive Economic Zone (EEZ) size data as magclass object.
+#' Areas with overlapping claims or jointly governed areas are split equally
+#' between the respective countries.
+#'
+#' @author Tabea Dorndorf
+#'
+readMarineRegionsOrg <- function() {
+  df <- readxl::read_xlsx(file.path("v10", "eez_v12.xlsx"))
+
+  # Select "ISO_SOV" instead of "ISO_TER". ISO_SOV assigns territories
+  # to their sovereign body (e.g. Alaska to USA, Cook Islands to NZL).
+  # Some territories do not have an ISO code. Chosing ISO_TER would thus reduce the
+  # area taken into consideration.
+  df <- df %>%
+    select(c("POL_TYPE", "ISO_SOV1", "ISO_SOV2", "ISO_SOV3", "AREA_KM2"))
+
+  # data adjustment: split areas between regions with joint regime or overlapping claims
+  df <- df %>%
+    # determine number of countries with claims for each area entry
+    mutate(claims = dplyr::case_when(
+      !is.na(ISO_SOV3) ~ 3,
+      !is.na(ISO_SOV2) ~ 2,
+      TRUE ~ 1
+    )) %>%
+    # adjust AREA_KM2 assigned to each country based on number of countries with claims
+    mutate(AREA_KM2_adj = .data$AREA_KM2 * (1 / .data$claims)) %>%
+    # convert wide to long format
+    tidyr::pivot_longer(
+      cols = c(ISO_SOV1, ISO_SOV2, ISO_SOV3),
+      names_to = "ISO_SOV_original",
+      values_to = "ISO_SOV"
+    ) %>%
+    # drop NAs
+    filter(!is.na(.data$ISO_SOV))
+
+  # aggregate to one value per country
+  df <- df %>%
+    select("Country" = "ISO_SOV", "Value" = "AREA_KM2_adj") %>%
+    dplyr::group_by(.data$Country) %>%
+    summarise(Value = sum(.data$Value))
+
+  # convert to magpie object
+  m <- as.magpie(df)
+
+  return(m)
+}

--- a/R/readMarineRegionsOrg.R
+++ b/R/readMarineRegionsOrg.R
@@ -26,7 +26,7 @@ readMarineRegionsOrg <- function() {
     mutate(AREA_KM2_adj = .data$AREA_KM2 * (1 / .data$claims)) %>%
     # convert wide to long format
     tidyr::pivot_longer(
-      cols = c(ISO_SOV1, ISO_SOV2, ISO_SOV3),
+      cols = c("ISO_SOV1", "ISO_SOV2", "ISO_SOV3"),
       names_to = "ISO_SOV_original",
       values_to = "ISO_SOV"
     ) %>%


### PR DESCRIPTION
This PR adds the source "MarineRegionsOrg" which provides data on the size of the exclusive economic zones (EEZ). 

The output is the share in total EEZ area by country/region. It will be used in 33_cdr for distribution of OAE.