### PR TITLE
Increase short-term ONONSPEC electricity projection in CHA

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '44602768'
+ValidationKey: '44631784'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.221.2
-date-released: '2025-03-17'
+version: 0.221.3
+date-released: '2025-03-21'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.221.2
-Date: 2025-03-17
+Version: 0.221.3
+Date: 2025-03-21
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcFeDemandONONSPEC.R
+++ b/R/calcFeDemandONONSPEC.R
@@ -110,20 +110,51 @@ calcFeDemandONONSPEC <- function(scenario, eoh) {
   }
 
 
+  .manipulateCHN <- function(x, how) {
+    mask <- x$region == "CHN" & x$item == "feothelec"
+    if ("eod" %in% colnames(x) && max(x$eod[mask]) >= 2025) {
+      stop("This manipulation was a temporary fix and should be removed ",
+           "now that data is available until 2025!")
+    }
+    switch(how,
+      dropOutlier = {
+        x <- x[!(mask & x$period == 2017), ]
+      },
+      boostSlope = {
+        x$slopeEOD <- x$slopeEOD * ifelse(mask, 5.2, 1)
+      },
+      fasterToConst = {
+        x$dt <- x$dt - ifelse(mask, 7, 0)
+      },
+      lowerTail = {
+        t <- x$period - (x$eod + x$dt * 0.7)
+        factor <- 0.7
+        factor <- (1 - factor) / (1 + exp(0.2 * t)) + factor
+        x$value <- x$value * ifelse(mask & x$period > eoh, factor, 1)
+      },
+      stop("Unknown manipulation.")
+    )
+    x
+  }
+
+
   .projectFlows <- function(flowsData) {
     flowsData %>%
       filter(!is.na(.data$value)) %>%
       group_by(dplyr::across(tidyselect::all_of(c("region", "item")))) %>%
       arrange(.data$period) %>%
+      .manipulateCHN("dropOutlier") %>%
       slice_tail(n = nTimeStepsEOD) %>%
       group_modify(.getEODcoefs) %>%
       group_modify(.expandPeriods) %>%
+      .manipulateCHN("boostSlope") %>%
       mutate(valueHist = .calcAsymptotic(xStart = .data$valueEOD,
                                          xDotStart = .data$slopeEOD,
                                          dt = yearsUntilConst[2],
                                          t = .data$period,
                                          tStart = .data$eod)) %>%
       group_modify(.expandScenarios, yearsUntilConst) %>%
+      .manipulateCHN("fasterToConst") %>%
       mutate(valueFuture = .calcAsymptotic(xStart = .data$valueHist[.data$period == eoh],
                                            xDotStart = .data$slopeEOD * constTolerance^((eoh - .data$eod) / yearsUntilConst[2]),
                                            dt = .data$dt - (eoh - .data$eod),
@@ -132,6 +163,7 @@ calcFeDemandONONSPEC <- function(scenario, eoh) {
                                            epsCorrection = -(eoh - .data$eod) / yearsUntilConst[2]),
              value = ifelse(.data$period > eoh, .data$valueFuture, .data$valueHist)) %>%
       ungroup() %>%
+      .manipulateCHN("lowerTail") %>%
       select("region", "period", "levelScen", "item", "value")
   }
 

--- a/R/calcFeDemandONONSPEC.R
+++ b/R/calcFeDemandONONSPEC.R
@@ -75,12 +75,12 @@ calcFeDemandONONSPEC <- function(scenario, eoh) {
   }
 
 
-  .getEODcoefs <- function(x, key) {
-    m <- stats::lm(value~period, x)
+  .getEODcoefs <- function(x, key, model = "linear") {
+    m <- stats::smooth.spline(x$period, x$value, spar = 0.7)
     eod <- max(x$period)
-    coefs <- data.frame(eod = eod,
-                        slopeEOD = stats::coef(m)[["period"]],
-                        valueEOD = stats::predict(m, list(period = eod)))
+    data.frame(eod = eod,
+               valueEOD = stats::predict(m, eod)$y,
+               slopeEOD = stats::predict(m, eod, deriv = 1)$y)
   }
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.221.2**
+R package **mrremind**, version **0.221.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.221.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.221.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-03-17},
+  date = {2025-03-21},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.221.2},
+  note = {Version: 0.221.3},
 }
 ```


### PR DESCRIPTION
To increase electricity demand from buildings in CHA in 2025, this PR increases the respective ONONSPEC projection. In this course, I also changed the regression for the end-of-data coefficients from a linear to a spline regression. This should help to capture non-linear trends. The impact on results is very small though:

![ononspecComparison_mainpulateCHN](https://github.com/user-attachments/assets/226a66de-0faa-4b5a-a8f7-6516be91518b)

The most notable change is the specifically manipulated electricity demand in CHA that should now close the gap to the 2025 target demand derived from extrapolating recent growth.

![grafik](https://github.com/user-attachments/assets/e792a362-fcc5-402b-9283-d0bc3c3fa9a8)
