### PR TITLE
Adapt maximum subsidy in LAM

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '45230108'
+ValidationKey: '45252525'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.224.2
-date-released: '2025-03-27'
+version: 0.224.3
+date-released: '2025-03-28'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.224.2
-Date: 2025-03-27
+Version: 0.224.3
+Date: 2025-03-28
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readREMIND_11Regi.R
+++ b/R/readREMIND_11Regi.R
@@ -22,7 +22,7 @@ readREMIND_11Regi <- function(subtype) {
     "capacityFactorRules"  = read.csv("f_cf-rules_v1.2.csv", sep = ";")          %>% as.magpie(datacol = 4),
     "storageFactor"        = read.csv("storageFactor.csv", sep = ";")            %>% as.magpie(datacol = 2),
     "taxConvergence"       = read.csv("tax_convergence.csv", sep = ";")          %>% as.magpie(datacol = 4),
-    "maxFeSubsidy"         = read.csv("max_FE_subsidy_REMIND_3.5.csv", sep = ";") %>% as.magpie(datacol = 4),
+    "maxFeSubsidy"         = read.csv("max_FE_subsidy_REMIND_3.5_v1.1.csv", sep = ";") %>% as.magpie(datacol = 4),
     "maxPeSubsidy"         = read.csv("max_PE_subsidy.csv", sep = ";")           %>% as.magpie(datacol = 4),
     "propFeSubsidy"        = read.csv("prop_FE_subsidy.csv", sep = ";")          %>% as.magpie(datacol = 4),
     "gridFactor"           = {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.224.2**
+R package **mrremind**, version **0.224.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,17 +39,15 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.224.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package - Version 0.224.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrremind: MadRat REMIND Input Data Package},
+  title = {mrremind: MadRat REMIND Input Data Package - Version 0.224.3},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-03-27},
+  date = {2025-03-28},
   year = {2025},
-  url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.224.2},
 }
 ```


### PR DESCRIPTION
Adapt the maximum subsidy for LAM in the file ```REMIND_11REGI/max_FE_subsidy.csv```, now renamed to ```REMIND_11REGI/max_FE_subsidy_3.5_v1.1.csv```; this further modifies the changes of PR #654.

The maximum subsidy was now further lowered to 3 2005$/GJ which by the unit conversion becomes 5 2017$/GJ.