### PR TITLE
Fix global hydro thresholds

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '45822220'
+ValidationKey: '45849219'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.227.0
-date-released: '2025-04-08'
+version: 0.227.1
+date-released: '2025-04-11'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.227.0
-Date: 2025-04-08
+Version: 0.227.1
+Date: 2025-04-11
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcProjectPipelines.R
+++ b/R/calcProjectPipelines.R
@@ -91,45 +91,45 @@ calcProjectPipelines <- function(subtype) {
 
     # Hydro ----
   } else if (subtype == "hydro") {
-    # Source 1: GEM
+    # Source 1: GEM -> currently too incomplete to be useful!
     # -> does not include units < 75MW
     # without pumped storage
-    x <- readSource("GlobalEnergyMonitor")
-    x <- x[, , "Hydro", pmatch = T]
-
-    # TODO: add pumped storage so it can be added to max bounds
-    #       -> not comparable to IEA until then
-
-    # initialize magclass object for thresholds
-    t <- new.magpie(getRegions(x),
-                    c(2020, 2025, 2030),
-                    c("GlobalEnergyMonitor.Cap|Electricity|Hydro.min_red.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Hydro.min_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Hydro.max_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Hydro.max_red.GW"),
-                    sets = getSets(x))
-
-    # ASSUMPTION: min_red
-    t[, , "min_red"] <- x[, , "operating"]
-
-    # ASSUMPTION: min_yel
-    t[, , "min_yel"] <- x[, , "operating"] +
-                        x[, , "construction"]*0.5 +
-                        x[, , "pre-construction"]*0.2
-
-    # ASSUMPTION: max_yel
-    t[, , "max_yel"] <- x[, , "operating"] +
-                        x[, , "construction"] +
-                        x[, , "pre-construction"]*0.8 +
-                        x[, , "announced"]*0.3
-
-    # ASSUMPTION: max_red
-    t[, , "max_red"] <- x[, , "operating"] +
-                        x[, , "construction"] +
-                        x[, , "pre-construction"] +
-                        x[, , "announced"]
-
-    x <- mbind(x, t)
+    # x <- readSource("GlobalEnergyMonitor")
+    # x <- x[, , "Hydro", pmatch = T]
+    #
+    # # TODO: add pumped storage so it can be added to max bounds
+    # #       -> not comparable to IEA until then
+    #
+    # # initialize magclass object for thresholds
+    # t <- new.magpie(getRegions(x),
+    #                 c(2020, 2025, 2030),
+    #                 c("GlobalEnergyMonitor.Cap|Electricity|Hydro.min_red.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Hydro.min_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Hydro.max_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Hydro.max_red.GW"),
+    #                 sets = getSets(x))
+    #
+    # # ASSUMPTION: min_red
+    # t[, , "min_red"] <- x[, , "operating"]
+    #
+    # # ASSUMPTION: min_yel
+    # t[, , "min_yel"] <- x[, , "operating"] +
+    #                     x[, , "construction"]*0.5 +
+    #                     x[, , "pre-construction"]*0.2
+    #
+    # # ASSUMPTION: max_yel
+    # t[, , "max_yel"] <- x[, , "operating"] +
+    #                     x[, , "construction"] +
+    #                     x[, , "pre-construction"]*0.8 +
+    #                     x[, , "announced"]*0.3
+    #
+    # # ASSUMPTION: max_red
+    # t[, , "max_red"] <- x[, , "operating"] +
+    #                     x[, , "construction"] +
+    #                     x[, , "pre-construction"] +
+    #                     x[, , "announced"]
+    #
+    # x <- mbind(x, t)
 
     # Source 2: IEA Hydropower Special Market Report
     # no access to granular data, only scraping online data explorer,
@@ -137,6 +137,12 @@ calcProjectPipelines <- function(subtype) {
     # pumped storage added to max only (accelerated case has no differentiation,
     # assume pumped storage equally to expected case)
     y <- readSource("IEA_HSMR")
+
+    # import "other" values that are missing towards global total separately
+    # z <- readSource("IEA_HSMR", convert = FALSE)
+    # z <- z["World", ,]
+    # getItems(z, dim = 1) <- "GLO"
+    # y <- mbind(y, z)
 
     # initialize magclass object for thresholds
     t <- new.magpie(getRegions(y),
@@ -164,7 +170,8 @@ calcProjectPipelines <- function(subtype) {
 
     # add empty 2025 column, so IEA and GEM data can be merged
     y <- add_columns(y, addnm = c("y2025"), dim = 2, fill= NA)
-    x <- mbind(x, y)
+    #x <- mbind(x, y)
+    x <- y
 
     # meta data
     unit <- "GW"
@@ -272,76 +279,76 @@ calcProjectPipelines <- function(subtype) {
   # Solar ----
   } else if (subtype == "solar") {
     # GEM probably not the best source for solar as smaller units are missing
-    x <- readSource("GlobalEnergyMonitor")
-    x <- x[, , "Solar", pmatch = T]
-
-    # lower bounds only, as solar can be built quickly
-    # TODO: PV/CSP differentiation
-    x <- x[, , "Cap|Electricity|Solar"]  # remove PV/CSP for now
-
-    # initialize magclass object for thresholds
-    t <- new.magpie(getRegions(x),
-                    c(2020, 2025, 2030),
-                    c("GlobalEnergyMonitor.Cap|Electricity|Solar.min_red.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Solar.min_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Solar.max_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Solar.max_red.GW"),
-                    sets = getSets(x))
-
-    # ASSUMPTION: min_red = operating
-    t[, , "min_red"] <- x[, , "operating"]
-    # ASSUMPTION: min_yel = operating + 0.5*construction + 0.2*pre-construction
-    t[, , "min_yel"] <- x[, , "operating"] +
-                        x[, , "construction"]*0.5 +
-                        x[, , "pre-construction"]*0.2
-
-    x <- mbind(x, t)
-
-    # meta data
-    unit <- "GW"
-    description <- "Solar project pipeline from GEM"
+    # x <- readSource("GlobalEnergyMonitor")
+    # x <- x[, , "Solar", pmatch = T]
+    #
+    # # lower bounds only, as solar can be built quickly
+    # # TODO: PV/CSP differentiation
+    # x <- x[, , "Cap|Electricity|Solar"]  # remove PV/CSP for now
+    #
+    # # initialize magclass object for thresholds
+    # t <- new.magpie(getRegions(x),
+    #                 c(2020, 2025, 2030),
+    #                 c("GlobalEnergyMonitor.Cap|Electricity|Solar.min_red.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Solar.min_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Solar.max_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Solar.max_red.GW"),
+    #                 sets = getSets(x))
+    #
+    # # ASSUMPTION: min_red = operating
+    # t[, , "min_red"] <- x[, , "operating"]
+    # # ASSUMPTION: min_yel = operating + 0.5*construction + 0.2*pre-construction
+    # t[, , "min_yel"] <- x[, , "operating"] +
+    #                     x[, , "construction"]*0.5 +
+    #                     x[, , "pre-construction"]*0.2
+    #
+    # x <- mbind(x, t)
+    #
+    # # meta data
+    # unit <- "GW"
+    # description <- "Solar project pipeline from GEM"
 
     # Wind ----
   } else if (subtype == "wind") {
     # GEM probably not the best source for Wind as smaller units are missing
-    x <- readSource("GlobalEnergyMonitor")
-    x <- x[, , "Wind", pmatch = T]
-
-    # TODO: On/Offshore differentiation
-    x <- x[, , "Cap|Electricity|Wind"]  # remove on/offshore for now
-
-
-    # initialize magclass object
-    t <- new.magpie(getRegions(x),
-                    c(2020, 2025, 2030),
-                    c("GlobalEnergyMonitor.Cap|Electricity|Wind.min_red.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Wind.min_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Wind.max_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Wind.max_red.GW"),
-                    sets = getSets(x))
-
-    # ASSUMPTION: min_red
-    t[, , "min_red"] <- x[, , "operating"]
-    # ASSUMPTION: min_yel
-    t[, , "min_yel"] <- x[, , "operating"] +
-                        x[, , "construction"]*0.5 +
-                        x[, , "pre-construction"]*0.2
-    # ASSUMPTION: max_yel
-    t[, , "max_yel"] <- x[, , "operating"] +
-                        x[, , "construction"] +
-                        x[, , "pre-construction"]*0.8 +
-                        x[, , "announced"]*0.3
-    # ASSUMPTION: max_red
-    t[, , "max_red"] <- x[, , "operating"] +
-                        x[, , "construction"] +
-                        x[, , "pre-construction"] +
-                        x[, , "announced"]
-
-    x <- mbind(x, t)
-
-    # meta data
-    unit <- "GW"
-    description <- "Wind project pipeline from GEM"
+    # x <- readSource("GlobalEnergyMonitor")
+    # x <- x[, , "Wind", pmatch = T]
+    #
+    # # TODO: On/Offshore differentiation
+    # x <- x[, , "Cap|Electricity|Wind"]  # remove on/offshore for now
+    #
+    #
+    # # initialize magclass object
+    # t <- new.magpie(getRegions(x),
+    #                 c(2020, 2025, 2030),
+    #                 c("GlobalEnergyMonitor.Cap|Electricity|Wind.min_red.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Wind.min_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Wind.max_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Wind.max_red.GW"),
+    #                 sets = getSets(x))
+    #
+    # # ASSUMPTION: min_red
+    # t[, , "min_red"] <- x[, , "operating"]
+    # # ASSUMPTION: min_yel
+    # t[, , "min_yel"] <- x[, , "operating"] +
+    #                     x[, , "construction"]*0.5 +
+    #                     x[, , "pre-construction"]*0.2
+    # # ASSUMPTION: max_yel
+    # t[, , "max_yel"] <- x[, , "operating"] +
+    #                     x[, , "construction"] +
+    #                     x[, , "pre-construction"]*0.8 +
+    #                     x[, , "announced"]*0.3
+    # # ASSUMPTION: max_red
+    # t[, , "max_red"] <- x[, , "operating"] +
+    #                     x[, , "construction"] +
+    #                     x[, , "pre-construction"] +
+    #                     x[, , "announced"]
+    #
+    # x <- mbind(x, t)
+    #
+    # # meta data
+    # unit <- "GW"
+    # description <- "Wind project pipeline from GEM"
 
   }
 

--- a/R/convertIEA_HSMR.R
+++ b/R/convertIEA_HSMR.R
@@ -5,6 +5,7 @@
 
 convertIEA_HSMR <- function(x) {
 
+  x <- x["World", , invert = TRUE]
   getItems(x, dim = 1) <- toolCountry2isocode(getItems(x, dim = 1))
   x <- toolCountryFill(x, fill = 0, verbosity = 2)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.227.0**
+R package **mrremind**, version **0.227.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.227.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.227.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-04-08},
+  date = {2025-04-11},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.227.0},
+  note = {Version: 0.227.1},
 }
 ```


### PR DESCRIPTION
Fixed global hydro thresholds from IEA HSMR where an incomplete country data set lead to the global aggregation being smaller than the reported total by IEA. Now, global data is read in separately in ``fullTHRESHOLDS`` and overwrites the automatic aggregation for this source. 

Also disabled some Global Energy Monitor functions as they are probably not useful because of incomplete data.