### PR TITLE
Update GEVO to 2025 value

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '46564856'
+ValidationKey: '46585084'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '46528521'
+ValidationKey: '46553346'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.230.1
-date-released: '2025-05-13'
+version: 0.230.2
+date-released: '2025-05-15'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.230.2
+version: 0.230.3
 date-released: '2025-05-20'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.230.1
-Date: 2025-05-13
+Version: 0.230.2
+Date: 2025-05-15
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.230.2
+Version: 0.230.3
 Date: 2025-05-20
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcIEA_EVOutlook.R
+++ b/R/calcIEA_EVOutlook.R
@@ -45,8 +45,8 @@ calcIEA_EVOutlook <- function() {
   }
 
   x <- toolAggregate(x,
-    dim = 3.2, rel = map, from = "Variable",
-    to = "REMIND", partrel = TRUE, verbosity = 2
+                     dim = 3.2, rel = map, from = "Variable",
+                     to = "REMIND", partrel = TRUE, verbosity = 2
   )
 
   getSets(x)[3.1] <- "model"

--- a/R/convertIEA_EVOutlook.R
+++ b/R/convertIEA_EVOutlook.R
@@ -5,7 +5,11 @@
 
 convertIEA_EVOutlook <- function(x) {
 
-  data <- x[c("World", "Rest of the world", "Europe", "EU27"), , invert = TRUE]
+  data <- x[c(
+    "World", "Rest of the world", "Europe", "EU27",
+    "Africa", "Asia Pacific", "Central and South America",
+    "Middle East and Caspian", "North America"
+  ), , invert = TRUE]
   getItems(data, dim = 1) <- toolCountry2isocode(getItems(data, dim = 1))
   data <- toolCountryFill(data, fill = NA, verbosity = 2)
 

--- a/R/readIEA_EVOutlook.R
+++ b/R/readIEA_EVOutlook.R
@@ -2,7 +2,11 @@
 #'
 #' @author Falk Benke
 readIEA_EVOutlook <- function() {
-  data <- utils::read.csv2(file.path("data", "2024", "IEA Global EV Data 2024.csv"), sep = ",")
+
+  data <- readxl::read_xlsx(
+    path = file.path("data", "2025", "EV Data Explorer 2025.xlsx"),
+    sheet = "GEVO_EV_2025"
+  )
 
   data <- data %>%
     mutate(
@@ -10,7 +14,13 @@ readIEA_EVOutlook <- function() {
       "value" = as.numeric(.data$value),
       "unit" = ifelse(is.na(.data$unit), "no", .data$unit)
     ) %>%
-    select("region", "year", "scenario" = "category", "variable", "unit", "value")
+    select("region" = "region_country", "year", "scenario" = "category", "variable", "unit", "value")
+
+  # assume that real duplicates can be removed
+  data <- distinct(data)
+
+  # entries with varying values are summed up
+  data <- aggregate(value ~ region + year + scenario + variable + unit, data, sum)
 
   as.magpie(data, spatial = 1)
 }

--- a/R/readIEA_EVOutlook.R
+++ b/R/readIEA_EVOutlook.R
@@ -20,7 +20,7 @@ readIEA_EVOutlook <- function() {
   data <- distinct(data)
 
   # entries with varying values are summed up
-  data <- aggregate(value ~ region + year + scenario + variable + unit, data, sum)
+  data <- stats::aggregate(value ~ region + year + scenario + variable + unit, data, sum)
 
   as.magpie(data, spatial = 1)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.230.1**
+R package **mrremind**, version **0.230.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-05-13},
+  date = {2025-05-15},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.230.1},
+  note = {Version: 0.230.2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.230.2**
+R package **mrremind**, version **0.230.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-05-20},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.230.2},
+  note = {Version: 0.230.3},
 }
 ```


### PR DESCRIPTION
Before after comparison can be found here: 
https://cloud.pik-potsdam.de/index.php/f/24141868

IEA GEVO APS seems to be no longer included