### PR TITLE
fix CCS data in historical.mif

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '46528521'
+ValidationKey: '46564856'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.230.1
-date-released: '2025-05-13'
+version: 0.230.2
+date-released: '2025-05-20'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.230.1
-Date: 2025-05-13
+Version: 0.230.2
+Date: 2025-05-20
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCCScapacity.R
+++ b/R/calcCCScapacity.R
@@ -10,10 +10,9 @@
 #' @export
 calcCCScapacity <- function(subtype) {
 
-  x <- calcOutput("ProjectPipelines", subtype = "CCS",
-                  aggregate = FALSE, warnNA = FALSE)
-
   if (subtype == "pipeline") {
+    x <- calcOutput("ProjectPipelines", subtype = "CCS",
+                    aggregate = FALSE, warnNA = FALSE)
     # used as input-data for CCS bounds
     x <- x[, c(2020, 2025, 2030), c("operational", "construction", "planned")]
     # remove "model", "variable" and "unit" dimension
@@ -22,9 +21,7 @@ calcCCScapacity <- function(subtype) {
 
   if (subtype == "historical") {
     # project pipeline snapshot from beginning of 2024
-    x <- x[, , "operational"]
-    # remove "status" and "unit" dimension
-    x <- collapseDim(x, keepdim = c("model", "variable", "period"))
+    x <- readSource("IEA_CCUS", subtype = "historical")
   }
 
   return(list(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.230.1**
+R package **mrremind**, version **0.230.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-05-13},
+  date = {2025-05-20},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.230.1},
+  note = {Version: 0.230.2},
 }
 ```


### PR DESCRIPTION
Changes from threshold calculation caused historical CCS data to be missing from historical.mif, this PR reintroduces it.