### PR TITLE
Enable reading in edgebuildings file with comment.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '46607616'
+ValidationKey: '46630150'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.230.4
-date-released: '2025-05-21'
+version: 0.230.5
+date-released: '2025-05-22'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.230.4
-Date: 2025-05-21
+Version: 0.230.5
+Date: 2025-05-22
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readEdgeBuildings.R
+++ b/R/readEdgeBuildings.R
@@ -11,8 +11,8 @@ readEdgeBuildings <- function(subtype = c("FE", "Floorspace"), subset) {
   subtype <- match.arg(subtype)
 
   # input data version
-  ver <- "2.4"
-  data <- read.csv(file.path(ver, "EDGE_buildings.csv"))
+  ver <- "2.4_test"
+  data <- read.csv(file.path(ver, "EDGE_buildings.csv"), comment.char = "*")
   data <- as.magpie(data)
 
   if (subtype == "FE") {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.230.4**
+R package **mrremind**, version **0.230.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,17 +39,15 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.230.4, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J (2025). "mrremind: MadRat REMIND Input Data Package - Version 0.230.5."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {mrremind: MadRat REMIND Input Data Package},
+  title = {mrremind: MadRat REMIND Input Data Package - Version 0.230.5},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch},
-  date = {2025-05-21},
+  date = {2025-05-22},
   year = {2025},
-  url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.230.4},
 }
 ```


### PR DESCRIPTION
From version 0.4.5, edgebuildings output for remind contains some comment lines with details on input data revision, edgebuildings version and date of creating.

This PR introduces some small changes in ```readEdgeBuildings``` so that the edgebuildings output with comment lines can be read by ```mrremind```.

@robinhasse @hagento As soon as we want to introduce a new version of edgebuildings results in ```mrremind```, we need to include this PR (and adjust the version number accordingly).