### PR TITLE
Air pollution new scenario logic for ScenarioMIP

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '47125425'
+ValidationKey: '47233760'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '47088888'
+ValidationKey: '47215120'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.232.4
-date-released: '2025-06-23'
+version: 0.233.0
+date-released: '2025-06-25'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.232.5
-date-released: '2025-06-30'
+version: 0.233.0
+date-released: '2025-07-03'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.232.5
-Date: 2025-06-30
+Version: 0.233.0
+Date: 2025-07-03
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.232.4
-Date: 2025-06-23
+Version: 0.233.0
+Date: 2025-06-25
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcAirPollEmiRef.R
+++ b/R/calcAirPollEmiRef.R
@@ -1,22 +1,16 @@
 #' Calculate air pollutant emissions for a reference year, for use
 #' in combination with GAINS data at different sectoral aggregations
 #'
-#'
+#' @param subtype just "total" is supported
 #' @param baseyear year to take as a reference from CEDS, ignored for the EDGAR2005 LUC CO2 emissions
+#' @param outunits "Mt/yr" or "kt/yr"
+#' @param namesformat "GAINS2025" or "REMIND" or "REMINDexo", the standard to use for pollutant names
 #' @return magclass object
 #' @author Gabriel Abrahao
 #' @importFrom magclass getNames<- getYears<-
 
 calcAirPollEmiRef <- function(
     subtype = "total", baseyear = 2020, outunits = "Mt/yr", namesformat = "GAINS2025") {
-  # require(tidyverse)
-  # require(madrat)
-  # require(magclass)
-  # require(mrcommons)
-  # subtype <- "total"
-  # baseyear <- 2020
-  # outunits <- "Mt/yr"
-  # namesformat <- "GAINS2025"
 
   # Mapping from GAINS to CEDS2025 pollutant names
   polnamesmap <- c(

--- a/R/calcGAINS2025forREMIND.R
+++ b/R/calcGAINS2025forREMIND.R
@@ -106,7 +106,10 @@ calcGAINS2025forREMIND <- function(subtype) {
 
     # Aggregate to REMIND sectors
     filtsecmap <- secmap[!(secmap$gains %in% dropsectors), ]
-    outnew <- toolAggregate(innew, filtsecmap, weight = NULL, from = "gains", to = "remind", dim = "sector")
+    # outnew <- toolAggregate(innew, filtsecmap, weight = NULL, from = "gains", to = "remind", dim = "sector")
+    # Here, zeroWeight = "allow" is allowing cases where there might be EFs, but all emissions are zero. In
+    # that case, that puts zero in the resulting EF.
+    outnew <- toolAggregate(innew, filtsecmap, weight = wgtnew, from = "gains", to = "remind", dim = "sector", zeroWeight = "allow")
     wgtnew <- toolAggregate(wgtnew, filtsecmap, weight = NULL, from = "gains", to = "remind", dim = "sector")
 
     # Use abind to split the dimensions of specific technologies into subsectors

--- a/R/calcGAINS2025forREMIND.R
+++ b/R/calcGAINS2025forREMIND.R
@@ -6,7 +6,8 @@
 #'
 #' @return Activity levels, emissions or emission factors
 #' @author Gabriel Abrahao
-#' @param subtype "emission_factors", "emissions","emissions_starting_values"
+#' @param subtype "emission_factors", "emissions","emission_factors_remindsectors",
+#' "emissions_starting_values" (not implemented)
 #'
 #' @importFrom abind abind
 #' @importFrom utils head tail

--- a/R/calcGAINS2025forREMIND.R
+++ b/R/calcGAINS2025forREMIND.R
@@ -152,8 +152,6 @@ calcGAINS2025forREMIND <- function(subtype) {
     # ==============================================================================================================
     out <- mbind(outold, outnew)
     wgt <- mbind(wgtold, wgtnew)
-    # str(out)
-    # str(wgt)
     desc <- getFromComment(innew, "description")
     unit <- getFromComment(innew, "unit")
   } else if (subtype == "emissions_exo_waste") {

--- a/R/calcGAINS2025forREMIND.R
+++ b/R/calcGAINS2025forREMIND.R
@@ -168,10 +168,4 @@ calcGAINS2025forREMIND <- function(subtype) {
     unit = unit,
     description = desc
   ))
-  #     calcOutput("EmiPollutantExo", subtype = "Waste",                              round = 6, file = "f11_emiAPexo.cs4r")
-  #   calcOutput("EmiAirPollLandUse",                                               round = 6, file = "f11_emiAPexoAgricult.cs4r")
-  #   calcOutput("GAINSEmi", subtype = "emissions",                                 round = 5, file = "emi_gains.cs4r")
-  #   calcOutput("GAINSEmi", subtype = "emission_factors",                          round = 5, file = "ef_gains.cs4r")
-  #   calcOutput("GAINSEmi", subtype = "emissions_starting_values",                 round = 5, file = "f11_emiAPexsolve.cs4r")
-  #   calcOutput("EmissionFactors", subtype = "emission_factors", warnNA = FALSE,   round = 5, file = "f11_emiFacAP.cs4r")
 }

--- a/R/calcGAINS2025scenarios.R
+++ b/R/calcGAINS2025scenarios.R
@@ -13,6 +13,7 @@
 #' @return Activity levels, emissions or emission factors
 #' @author Gabriel Abrahao
 #' @param subtype "emission_factors", "emissions","emissions_starting_values"
+#' @param agglevel "agg" or "det", sectoral aggregation level
 #'
 #' @importFrom magclass as.magpie
 #' @importFrom tidyr pivot_longer drop_na

--- a/R/calcGAINS2025scenarios.R
+++ b/R/calcGAINS2025scenarios.R
@@ -281,17 +281,6 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
   # ====================================================================
   # SMOOTHING ==========================================================
   # ====================================================================
-  # # Smoothing the phase-in from historical by assuming
-  # # 2025=2030, it appears that 2025 was a transition year in the original.
-  #
-  # efs[, 2025, ] <- efs[, 2030, ]
-
-  # # Smooth post-2050 transition, that is often very abrupt
-  # sy <- 2050
-  # ey <- 2080
-  # inyears <- allyears[(allyears > sy & allyears < ey)]
-  # efs <- time_interpolate(efs[, inyears, , invert = T], allyears)
-
   # VLE (Very strong LEgislation) scenario
   # SLE until 2050, then converges towards MFR in 2100
   allyears <- getYears(efs, as.integer = T)
@@ -430,7 +419,6 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
 
       out <- outsspefs * conv_kt_per_PJ_to_Tg_per_TWa
       wgt <- mbind(lapply(getItems(outsspefs, "scenario"), \(x) add_dimension(outsspact, dimCode("scenario", outsspefs), "scenario", x)))
-      # wgt <- outsspact
       unit <- "Tg/TWa"
     }
   } else {

--- a/R/convertIMAGE2025.R
+++ b/R/convertIMAGE2025.R
@@ -3,6 +3,9 @@
 #'
 #' @return magpie object
 #' @author Gabriel Abrahao
+#' 
+#' @param x magpie object
+
 convertIMAGE2025 <- function(x) {
   w <- readSource("EDGAR", subtype = "HFC")
   w[is.na(w)] <- 0

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -41,13 +41,14 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
 
       out <- collapseDim(baseactemi[, , subtypecode], "vartype")
       comment(out) <- paste0("GAINS2025 ", subtype, " for scenario ", scenario, " at aggregation level ", agglevel)
-    } else if (scenario != "baseline") {
+    } else if (!(scenario %in% c("baseline","scenariomip"))) {
       if (subtype != "emifacs") {
         stop("Only emission factors are available for scenarios other than the historical baseline")
       }
       # Reading scenario emission factors. Here there is also a SSP dimension
-      inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-03-25.csv"))
-
+      # inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-03-25.csv"))
+      inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-06-24.csv"))
+      
       # Convert to long format
       longefs <- pivot_longer(inefs, 5:length(names(inefs)), names_prefix = "X", names_to = "year")
 
@@ -58,6 +59,23 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
       out <- as.magpie(longefs, spatial = "region", temporal = "year")
       comment(out) <- paste0(
         "GAINS2025 emission factors for scenario ", scenario, " and all SSPs at aggregation level ", agglevel
+      )
+    } else if (scenario == "scenariomip") {
+      if (subtype != "emifacs") {
+        stop("Only emission factors are available for scenarios other than the historical baseline")
+      }
+      # Reading emission factors for the ScenarioMIP combinations
+      inefs <- read.csv(paste0("emission_factors_", agglevel, "_ssp_variant_final_2025-06-24.csv"))
+
+      # Convert to long format
+      longefs <- pivot_longer(inefs, 7:length(names(inefs)), names_prefix = "X", names_to = "year")
+      longefs <- longefs[, -1]
+
+      names(longefs) <- c("ssp", "scenario", "region", "sectorGAINS", "species", "year", "value")
+
+      out <- as.magpie(longefs, spatial = "region", temporal = "year")
+      comment(out) <- paste0(
+        "GAINS2025 emission factors for ScenarioMIP scenarios and selected SSPs at aggregation level ", agglevel
       )
     }
   } else if (subtype == "GCI") {

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -27,7 +27,8 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         stop("Only emission and activities are available for the historical baseline")
       }
       # Reading baseline scenario activities and emissions
-      inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-03-25.csv"))
+      # inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-03-25.csv"))
+      inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-06-30.csv"))      
 
       # Drop scenario dimension as we only have the baseline in the file
       inbaseactemi <- inbaseactemi[, -1]
@@ -35,7 +36,7 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         inbaseactemi, 5:length(names(inbaseactemi)),
         names_prefix = "X", names_to = "year"
       )
-      head(longbaseactemi)
+      
       names(longbaseactemi) <- c("region", "sectorGAINS", "species", "vartype", "year", "value")
       baseactemi <- as.magpie(longbaseactemi, spatial = "region", temporal = "year")
 

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -48,7 +48,6 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         )
       } else {
         # Reading baseline scenario activities and emissions
-        # inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-03-25.csv"))
         inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-06-30.csv"))
 
         # Drop scenario dimension as we only have the baseline in the file
@@ -69,7 +68,6 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         stop("Only emission factors are available for scenarios other than the historical baseline")
       }
       # Reading scenario emission factors. Here there is also a SSP dimension
-      # inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-03-25.csv"))
       inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-06-24.csv"))
 
       # Convert to long format

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -46,23 +46,24 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         comment(out) <- paste0(
           "GAINS2025 emission factors for ScenarioMIP scenarios and selected SSPs at aggregation level ", agglevel
         )
+      } else {
+        # Reading baseline scenario activities and emissions
+        # inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-03-25.csv"))
+        inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-06-30.csv"))
+
+        # Drop scenario dimension as we only have the baseline in the file
+        inbaseactemi <- inbaseactemi[, -1]
+        longbaseactemi <- pivot_longer(
+          inbaseactemi, 5:length(names(inbaseactemi)),
+          names_prefix = "X", names_to = "year"
+        )
+
+        names(longbaseactemi) <- c("region", "sectorGAINS", "species", "vartype", "year", "value")
+        baseactemi <- as.magpie(longbaseactemi, spatial = "region", temporal = "year")
+
+        out <- collapseDim(baseactemi[, , subtypecode], "vartype")
+        comment(out) <- paste0("GAINS2025 ", subtype, " for scenario ", scenario, " at aggregation level ", agglevel)
       }
-      # Reading baseline scenario activities and emissions
-      # inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-03-25.csv"))
-      inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-06-30.csv"))
-
-      # Drop scenario dimension as we only have the baseline in the file
-      inbaseactemi <- inbaseactemi[, -1]
-      longbaseactemi <- pivot_longer(
-        inbaseactemi, 5:length(names(inbaseactemi)),
-        names_prefix = "X", names_to = "year"
-      )
-
-      names(longbaseactemi) <- c("region", "sectorGAINS", "species", "vartype", "year", "value")
-      baseactemi <- as.magpie(longbaseactemi, spatial = "region", temporal = "year")
-
-      out <- collapseDim(baseactemi[, , subtypecode], "vartype")
-      comment(out) <- paste0("GAINS2025 ", subtype, " for scenario ", scenario, " at aggregation level ", agglevel)
     } else if (!(scenario %in% c("baseline", "scenariomip"))) {
       if (subtype != "emifacs") {
         stop("Only emission factors are available for scenarios other than the historical baseline")

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -10,6 +10,7 @@
 #' extensions.
 #' @author Gabriel Abrahao
 #' @param subtype "emifacs", "emissions","activities", "GCI"
+#' @param subset scenario and aggregation level ("agg" or "det"), separated by a dot
 #'
 #' @importFrom magclass as.magpie
 #' @importFrom tidyr pivot_longer drop_na

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.232.5**
+R package **mrremind**, version **0.233.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.232.5, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.233.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-06-30},
+  date = {2025-07-03},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.232.5},
+  note = {Version: 0.233.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.232.4**
+R package **mrremind**, version **0.233.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.232.4, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.233.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-06-23},
+  date = {2025-06-25},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.232.4},
+  note = {Version: 0.233.0},
 }
 ```

--- a/man/calcAirPollEmiRef.Rd
+++ b/man/calcAirPollEmiRef.Rd
@@ -13,7 +13,13 @@ calcAirPollEmiRef(
 )
 }
 \arguments{
+\item{subtype}{just "total" is supported}
+
 \item{baseyear}{year to take as a reference from CEDS, ignored for the EDGAR2005 LUC CO2 emissions}
+
+\item{outunits}{"Mt/yr" or "kt/yr"}
+
+\item{namesformat}{"GAINS2025" or "REMIND" or "REMINDexo", the standard to use for pollutant names}
 }
 \value{
 magclass object

--- a/man/calcGAINS2025forREMIND.Rd
+++ b/man/calcGAINS2025forREMIND.Rd
@@ -11,7 +11,8 @@ see \code{GAINS2025scenarios}.}
 calcGAINS2025forREMIND(subtype)
 }
 \arguments{
-\item{subtype}{"emission_factors", "emissions","emissions_starting_values"}
+\item{subtype}{"emission_factors", "emissions","emission_factors_remindsectors",
+"emissions_starting_values" (not implemented)}
 }
 \value{
 Activity levels, emissions or emission factors

--- a/man/calcGAINS2025scenarios.Rd
+++ b/man/calcGAINS2025scenarios.Rd
@@ -10,6 +10,8 @@ calcGAINS2025scenarios(subtype, agglevel = "agg")
 }
 \arguments{
 \item{subtype}{"emission_factors", "emissions","emissions_starting_values"}
+
+\item{agglevel}{"agg" or "det", sectoral aggregation level}
 }
 \value{
 Activity levels, emissions or emission factors

--- a/man/convertIMAGE2025.Rd
+++ b/man/convertIMAGE2025.Rd
@@ -7,6 +7,9 @@ using EDGAR HFC emissions in 2005 as weights}
 \usage{
 convertIMAGE2025(x)
 }
+\arguments{
+\item{x}{magpie object}
+}
 \value{
 magpie object
 }

--- a/man/readGAINS2025.Rd
+++ b/man/readGAINS2025.Rd
@@ -7,7 +7,9 @@
 readGAINS2025(subtype, subset = "baseline.det")
 }
 \arguments{
-\item{subtype}{"emission_factors", "emissions","emissions_starting_values"}
+\item{subtype}{"emifacs", "emissions","activities", "GCI"}
+
+\item{subset}{scenario and aggregation level ("agg" or "det"), separated by a dot}
 }
 \value{
 Activity levels, emissions or emission factors. Alternatively,


### PR DESCRIPTION
This PR updates all new air pollution scenarios (`GAINS2025`) to use the June 24th data from Zig, and adds two more scenarios specific for ScenarioMIP. The legacy scenarios (`GAINSlegacy`) are untouched, and include some scenarios that seem scenario-specific (Namely `MFR_Transports`, `SLCF_building_transport`, `FLE_building_transport`, `GlobalEURO6`) that were not updated. Sector and Europe people (@robertpietzcker @Renato-Rodrigues ) please take note and let us know if we need to do something about them. If we don't, the old implementation will still work, but with old EFs. 

Now we have 6 AP scenarios in REMIND instead of the old 4, each with all SSP variations. The new ScenarioMIP approach from Zig does away with the CLE/SLE logic and basically maps scenarios to their SSPs, with small variations except for VLLO. So the idea here is to keep the CLE/SLE logic (for other non-ScenarioMIP applications) and add two scenarios, one that is specifically for ScenarioMIP VLLO and one that is the ScenarioMIP choice for each SSP in non-VLLO scenarios. So we have:

- CLE
  - Current legislation, IIASA-internal
- SLE
   - Stronger legislation, IIASA-internal
- MFR
   - Maximum Feasible Reduction. Not really intended for use, and more as a technical reference. Identical for all SSPs.
- VLE
   - Very strong legislation, ad-hoc, follows SLE until 2050 and then converges towards MFR in 2100
- SMIPperSSP
   - IIASA's choice for all ScenarioMIP scenarios except VLLO. The logic is a combination of CLE, SLE and MFR, with substantial variation across SSPs based on Marina's GCI. 
- SMIPVLLO
   - IIASA's choice for ScenarioMIP's VLLO, with a specific logic. Also varies by SSP, but only between SSP1 and SSP2. Other SSPs are a repetition of SSP2 for completeness sake. 

In general (but by no means always), the scenarios look like the example below for `pecoal.seel.pc.power`. The new CLE (SSP1 and SSP2) is generally a bit lower than the old one in `GAINSlegacy`, and varies just a bit with SSPs. `SMIPbySSP` naturally varies much more, and is generally much lower than CLE. `SSPVLLO` is close but lower than `SMIPbySSP.SSP1`. 
   
|   |  |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/b086c4ff-88af-4fc9-a301-ff3fbad315cc)  | ![image](https://github.com/user-attachments/assets/42ceb990-42c3-4399-9010-1dd2c46dd37d)  |

 I still have quite a lot of illness brain fog, so it would be great to have some eyes on those @nicobauer @laurinks @merfort @robertpietzcker . Here are plots for all the EFs that are used in the optimization (missing those that just go through `exoGAINS`)
 
[remefs_all.pdf](https://github.com/user-attachments/files/20908210/remefs_all.pdf)

Addresses [development_issues 591](https://github.com/remindmodel/development_issues/issues/591)

 
 