### PR TITLE
Hopefully final AP emission factors update

### DIFF
--- a/R/calcGAINS2025scenarios.R
+++ b/R/calcGAINS2025scenarios.R
@@ -182,7 +182,7 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
         dumfill, getItems(magscen, "ssp"), "ssp", 3.1
       ), getItems(magscen, "scenario"), "scenario", 3.1
     )
-    dumfill <- mbind(lapply(getYears(magscen), \(yr) setYears(dumfill[,useyear,], yr)))
+    dumfill <- mbind(lapply(getYears(magscen), \(yr) setYears(dumfill[, useyear, ], yr)))
     magscen <- mbind(magscen, dumfill)
     return(magscen)
   }
@@ -318,7 +318,7 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
   # Reference GDP relative change between 2025 and 2050
   refrgdp <- setYears(gdpgains[, 2050, "SSP2"], NULL) / setYears(gdpgains[, 2025, "SSP2"], NULL)
 
-  # Estimate elasticities of the GDP-activities relationship. 
+  # Estimate elasticities of the GDP-activities relationship.
   # Surpress warnings as all generated NaNs were checked and handled below
   estela <- suppressWarnings(collapseDim(log(refract) / log(refrgdp)))
   # Cap elasticies to avoid extreme values
@@ -426,7 +426,11 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
       outsspefs <- padMissingSectors(outsspefs, seclist)
 
       out <- outsspefs * conv_kt_per_PJ_to_Tg_per_TWa
-      wgt <- mbind(lapply(getItems(outsspefs, "scenario"), \(x) add_dimension(outsspact, dimCode("scenario", outsspefs), "scenario", x)))
+      wgt <- mbind(
+        lapply(getItems(outsspefs, "scenario"), \(x) add_dimension(
+          outsspact, dimCode("scenario", outsspefs), "scenario", x
+        ))
+      )
       unit <- "Tg/TWa"
     }
   } else {

--- a/R/calcGAINS2025scenarios.R
+++ b/R/calcGAINS2025scenarios.R
@@ -70,9 +70,9 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
   baseefs <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("baseline.", agglevel))
 
   # GAINS scenarios
-  incle <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("CLE.", agglevel))
-  inmid <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("SLE.", agglevel))
-  inmfr <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("MTFR.", agglevel))
+  incle <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("cle_rev.", agglevel))
+  inmid <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("middle.", agglevel))
+  inmfr <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("mtfr.", agglevel))
   # Using scenario names closer to the usual IIASA ones
   getItems(incle, "scenario") <- "CLE"
   getItems(inmid, "scenario") <- "SLE"

--- a/R/calcGAINS2025scenarios.R
+++ b/R/calcGAINS2025scenarios.R
@@ -88,9 +88,9 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
     det_baseemi <- readSource("GAINS2025", subtype = "emissions", subset = paste0("baseline.", "det"))
     det_baseact <- readSource("GAINS2025", subtype = "activities", subset = paste0("baseline.", "det"))
     det_baseefs <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("baseline.", "det"))
-    det_incle <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("CLE.", "det"))
-    det_inmid <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("SLE.", "det"))
-    det_inmfr <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("MTFR.", "det"))
+    det_incle <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("cle_rev.", "det"))
+    det_inmid <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("middle.", "det"))
+    det_inmfr <- readSource("GAINS2025", subtype = "emifacs", subset = paste0("mtfr.", "det"))
     getItems(det_incle, "scenario") <- "CLE"
     getItems(det_inmid, "scenario") <- "SLE"
     getItems(det_inmfr, "scenario") <- "MFR"
@@ -211,8 +211,10 @@ calcGAINS2025scenarios <- function(subtype, agglevel = "agg") {
   dum1 <- setItems(insmp[, , "SSP1.Medium"], "scenario", "SMIPbySSP")
   dum2 <- setItems(insmp[, , "SSP2.Medium"], "scenario", "SMIPbySSP")
   dum3 <- setItems(insmp[, , "SSP3.Medium"], "scenario", "SMIPbySSP")
-  dum4 <- setItems(insmp[, , "SSP4.Low Overshoot"], "scenario", "SMIPbySSP")
+  # dum4 <- setItems(insmp[, , "SSP4.Low Overshoot"], "scenario", "SMIPbySSP")
   dum5 <- setItems(insmp[, , "SSP5.High"], "scenario", "SMIPbySSP")
+  # GA: Final data does not have SSP4, copying it from SSP3
+  dum4 <- setItems(setItems(insmp[, , "SSP3.Medium"], "scenario", "SMIPbySSP"), "ssp", "SSP4")
 
   smpbyssp <- mbind(dum1, dum2, dum3, dum4, dum5)
   smpbyssp <- dimOrder(smpbyssp, perm = c(2, 1, 3, 4))

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -29,13 +29,7 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         # GA: This if condition is temporary, until we get a file for the detailed aggregation level
         # for the FINAL_2025-07-01 version. But the other version is compatible with it, so this ultimately
         # only means that Municipal Waste EFs are read from the old version in calcGAINS2025scenarios
-        if (agglevel == "det") {
-          inefs <- read.csv(paste0("emission_factors_", agglevel, "_hist_final_2025-07-02.csv"))
-        } else {
-          inefs <- read.csv(paste0("emission_factors_", agglevel, "_hist_FINAL-2025-07-01.csv"))
-          inefs <- inefs[!grepl("^[ ]*$", inefs$EMF30_AGG), ] # Version FINAL_2025-07-01 has a " " sector
-        }
-
+        inefs <- read.csv(paste0("emission_factors_", agglevel, "_hist_final_2025-07-02.csv"))
 
         # Convert to long format
         longefs <- pivot_longer(inefs, 7:length(names(inefs)), names_prefix = "X", names_to = "year")

--- a/R/readGAINS2025.R
+++ b/R/readGAINS2025.R
@@ -30,7 +30,7 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         # for the FINAL_2025-07-01 version. But the other version is compatible with it, so this ultimately
         # only means that Municipal Waste EFs are read from the old version in calcGAINS2025scenarios
         if (agglevel == "det") {
-          inefs <- read.csv(paste0("emission_factors_", agglevel, "_hist_final_2025-06-24.csv"))
+          inefs <- read.csv(paste0("emission_factors_", agglevel, "_hist_final_2025-07-02.csv"))
         } else {
           inefs <- read.csv(paste0("emission_factors_", agglevel, "_hist_FINAL-2025-07-01.csv"))
           inefs <- inefs[!grepl("^[ ]*$", inefs$EMF30_AGG), ] # Version FINAL_2025-07-01 has a " " sector
@@ -49,7 +49,7 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         )
       } else {
         # Reading baseline scenario activities and emissions
-        inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-06-30.csv"))
+        inbaseactemi <- read.csv(paste0("IMAGE_emf_", agglevel, "_activity_emission_2025-07-02.csv"))
 
         # Drop scenario dimension as we only have the baseline in the file
         inbaseactemi <- inbaseactemi[, -1]
@@ -69,7 +69,7 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
         stop("Only emission factors are available for scenarios other than the historical baseline")
       }
       # Reading scenario emission factors. Here there is also a SSP dimension
-      inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-06-24.csv"))
+      inefs <- read.csv(paste0("SSPs_IMAGE_emf_", agglevel, "_", scenario, "_2025-07-02.csv"))
 
       # Convert to long format
       longefs <- pivot_longer(inefs, 5:length(names(inefs)), names_prefix = "X", names_to = "year")
@@ -90,13 +90,7 @@ readGAINS2025 <- function(subtype, subset = "baseline.det") {
       # GA: This if condition is temporary, until we get a file for the detailed aggregation level
       # for the FINAL_2025-07-01 version. But the other version is compatible with it, so this ultimately
       # only means that Municipal Waste EFs are read from the old version in calcGAINS2025scenarios
-      if (agglevel == "det") {
-        inefs <- read.csv(paste0("emission_factors_", agglevel, "_ssp_variant_final_2025-06-24.csv"))
-      } else {
-        inefs <- read.csv(paste0("emission_factors_", agglevel, "_ssp_variant_FINAL_2025-07-01.csv"))
-        inefs <- inefs[!grepl("^[ ]*$", inefs$EMF30_AGG), ] # Version FINAL_2025-07-01 has a " " sector
-      }
-
+      inefs <- read.csv(paste0("emission_factors_", agglevel, "_ssp_variant_final_2025-07-02.csv"))
 
       # Convert to long format
       longefs <- pivot_longer(inefs, 7:length(names(inefs)), names_prefix = "X", names_to = "year")


### PR DESCRIPTION
This updates all the non-legacy air pollution emission factors, including the CLE, SLE, etc. and the ScenarioMIP sets of scenarios (see #695 for implementation and scenario details) to use the data received from Zig on July 3rd, 

### EF plots
#### All sectors used in exoGAINS
General scenario comparison
[rawefs_agg.pdf](https://github.com/user-attachments/files/21040793/rawefs_agg.pdf)
Zooming in on ScenarioMIP scenarios and SSPs
[smiprawefs_agg.pdf](https://github.com/user-attachments/files/21040781/smiprawefs_agg.pdf)

#### REMIND sectors
There was a major overhaul in the sector aggregation weighting that I think is a lot more sensible now. Expect differences especially in sectors that had a many-to-many mapping, most notably `pecoal.sesofos.coaltr.indst`
[emefs4remind__all.pdf](https://github.com/user-attachments/files/21040731/emefs4remind__all.pdf)
