### PR TITLE
convert capacity factor data in REMIND_11Regi to Expert Guess

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '47313240'
+ValidationKey: '47320239'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '47292960'
+ValidationKey: '47313240'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.233.2
+version: 0.233.3
 date-released: '2025-07-11'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
 version: 0.233.3
-date-released: '2025-07-11'
+date-released: '2025-07-14'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.233.2
+Version: 0.233.3
 Date: 2025-07-11
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
 Version: 0.233.3
-Date: 2025-07-11
+Date: 2025-07-14
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCapacityFactor.R
+++ b/R/calcCapacityFactor.R
@@ -8,14 +8,15 @@
 #' }
 #'
 calcCapacityFactor <- function() {
+
   ### calculation of coal power capacity factor
   GWh_2_EJ <- 3.6e-6
 
   # Taken from the plyr package
-  round_any <- function(x, accuracy, f = round) f(x/ accuracy) * accuracy
+  round_any <- function(x, accuracy, f = round) f(x / accuracy) * accuracy
 
   # Read capacity factor inputs
-  global <- readSource("REMIND_11Regi", subtype = "capacityFactorGlobal", convert = FALSE)
+  global <- readSource("ExpertGuess", subtype = "capacityFactorGlobal", convert = FALSE)
 
   # remove no longer used items
   notUsed <- c("apcarelt", "aptrnelt", "apcarh2t", "apcarpet", "apcardit",
@@ -25,7 +26,7 @@ calcCapacityFactor <- function() {
   # Set coal plant capacity factor long-term assumption to 50% (down from 60%)
   global[, , "pc"] <- 0.5
   # Read capacity factor rules
-  rules <- readSource("REMIND_11Regi", subtype = "capacityFactorRules")
+  rules <- readSource("ExpertGuess", subtype = "capacityFactorRules")
 
   #   Creating new MAgPIE object to store the final capacity values
   output <- new.magpie(getRegions(rules), seq(2005, 2150, 5), getNames(global))

--- a/R/convertExpertGuess.R
+++ b/R/convertExpertGuess.R
@@ -3,21 +3,28 @@
 #' @param x unconverted magpie object from read-script
 #' @param subtype Type of data that are converted.
 #'
-#'
 convertExpertGuess <- function(x, subtype) {
-  if (subtype == "costsTradePeFinancial") {
-    # use data for each country that belongs to a region
-    # No weighting for spatial aggregation
-    out <- toolAggregate(x, toolGetMapping(
-      type = "regional", name = "regionmappingH12.csv",
-      returnPathOnly = TRUE, where = "mappingfolder"
-    ),
-    weight = NULL
-    )
-  } else if (subtype %in% c("taxConvergenceRollback", "subConvergenceRollback")) {
+
+  if (subtype %in% c(
+    "capacityFactorRules",
+    "costsTradePeFinancial",
+    "subConvergenceRollback",
+    "taxConvergenceRollback"
+  )) {
+
+    # source data for these types is in H12 regions
+    # use the region data for each country that belongs to the region
+    # no weighting for spatial aggregation
+
+    # Replacing NA values with zero
+    x[is.na(x)] <- 0
+
     mapping <- toolGetMapping(type = "regional", name = "regionmappingH12.csv", where = "mappingfolder")
-    out <- toolAggregate(x, mapping, weight = NULL, from = "RegionCode", to = "CountryCode", partrel = TRUE) %>%
-      toolCountryFill(fill = 0)
+
+    out <- toolAggregate(x, rel = mapping, weight = NULL,
+                         from = "RegionCode", to = "CountryCode", partrel = TRUE) %>%
+      toolCountryFill(fill = 0, verbosity = 2)
+
   } else {
     out <- x
   }

--- a/R/convertREMIND_11Regi.R
+++ b/R/convertREMIND_11Regi.R
@@ -2,16 +2,11 @@
 #'
 #' @param x MAgPIE object to be converted
 #' @param subtype Name of the regional data, e.g. tradecost", "pe2se",
-#' "deltacapoffset", capacityFactorRules", "taxConvergence", "maxFeSubsidy",
+#' "deltacapoffset", "taxConvergence", "maxFeSubsidy",
 #' "maxPeSubsidy", "propFeSubsidy", "fossilExtractionCoeff", "uraniumExtractionCoeff"
 #' @return A MAgPIE object containing country disaggregated data
-#' @author original: not defined - capacity factor, tax, fossil and RLDC changes: Renato Rodrigues
-#' @examples
+#' @author original: not defined - tax, fossil and RLDC changes: Renato Rodriguess
 #'
-#' \dontrun{ a <- convertREMIND_11Regi(x,subtype="capacityFactorGlobal")
-#' }
-#'
-
 convertREMIND_11Regi <- function(x,subtype) {
 
   if(subtype == "tradecost" | subtype == "storageFactor" | subtype == "ffPolyRent" ){
@@ -23,7 +18,7 @@ convertREMIND_11Regi <- function(x,subtype) {
   } else if (subtype == "deltacapoffset") {
     fe <- dimSums(calcOutput("IO",subtype="output",aggregate=FALSE)[,2010,c("feelb","feeli")],dim=3)
     y <- toolAggregate(x,"regionmappingREMIND.csv",weight=fe)
-  } else if (subtype=="capacityFactorRules" | subtype == "taxConvergence" | subtype == "maxFeSubsidy" |
+  } else if (subtype == "taxConvergence" | subtype == "maxFeSubsidy" |
              subtype == "maxPeSubsidy" | subtype == "propFeSubsidy") {
     # Loading REMIND old region mapping
     mapping <- toolGetMapping(type = "regional", name = "regionmappingREMIND.csv", where = "mappingfolder")

--- a/R/readAGEB.R
+++ b/R/readAGEB.R
@@ -47,11 +47,11 @@ readAGEB <- function(subtype = "balances") {
         "6.8 Endenergieverbrauch im Subsektor Strassenverkehr nach Energietraegern"
       ),
       range = c(
-        "B4:AK13", "B4:AK15", "B4:AK15", "B4:AK15", "B4:AK10",
-        "B4:AK15", "B4:AK16",
-        "B4:AK15",
-        "B4:AK15", "B4:AK15",
-        "B4:AK15", "B4:AK15", "B4:AK15", "B4:AK15", "B4:AK15", "B4:AK15", "B4:AK13", "B4:AK12"
+        "B4:AL13", "B4:AL15", "B4:AL15", "B4:AL15", "B4:AL10",
+        "B4:AL15", "B4:AL16",
+        "B4:AL15",
+        "B4:AL15", "B4:AL15",
+        "B4:AL15", "B4:AL15", "B4:AL15", "B4:AL15", "B4:AL15", "B4:AL15", "B4:AL13", "B4:AL12"
       )
     )
 
@@ -60,12 +60,12 @@ readAGEB <- function(subtype = "balances") {
     for (i in seq_len(nrow(sheets))) {
       tmp <- suppressWarnings(
         read_xlsx(
-          path = "EBD23e_Auswertungstabellen_deutsch.xlsx", sheet = sheets[["sheet"]][[i]], col_names = TRUE,
-          col_types = c("text", "text", rep("numeric", 34)),
+          path = "EBD24p1_Auswertungstabellen_deutsch.xlsx", sheet = sheets[["sheet"]][[i]], col_names = TRUE,
+          col_types = c("text", "text", rep("numeric", 35)),
           range = sheets[["range"]][[i]], .name_repair = "minimal", na = c("n/a")
         )
       ) %>%
-        filter(!is.na(!!sym("Einheit"))) %>%
+        filter(!is.na(.data$Einheit)) %>%
         mutate("Energietraeger" = paste0(sheets[["name"]][[i]], "|", !!sym("Energietr\u00E4ger"))) %>%
         select(-1)
 

--- a/R/readAGEB.R
+++ b/R/readAGEB.R
@@ -85,18 +85,19 @@ readAGEB <- function(subtype = "balances") {
 
     sheets <-  tibble(
       sheet = c("STRERZ (brutto)", "STRERZ (netto)"),
-      prefix = c("9 Bruttostromerzeugung", "10 Nettostromerzeugung")
+      prefix = c("9 Bruttostromerzeugung", "10 Nettostromerzeugung"),
+      range = c("B3:AK29", "B3:AK23")
     )
 
     data <- NULL
 
     for (i in seq_len(nrow(sheets))) {
       tmp <- read_xlsx(
-        path = "STRERZ_Abg_02_2024_korr.xlsx",
+        path = "STRERZ-Abgabe-2025-02.xlsx",
         sheet = sheets[["sheet"]][[i]],
         col_names = TRUE,
-        col_types = c("text", rep("numeric", 34)),
-        range = "B3:AJ23", .name_repair = "minimal", na = c("k.A.")
+        col_types = c("text", rep("numeric", 35)),
+        range = sheets[["range"]][[i]],, .name_repair = "minimal", na = c("k.A.")
       ) %>%
         mutate("TWh" = gsub(", darunter:", "", .data$TWh)) %>%
         mutate("TWh" = gsub("- ", "", .data$TWh)) %>%

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -4,6 +4,10 @@
 #'
 #' @md
 #' @param subtype Type of data that should be read.  One of
+#'   - `capacityFactorGlobal`: Global capacity factors for all REMIND technologies
+#'   - `capacityFactorRules`: Capacity factor rules for selected H12 regions and REMIND technologies
+#'   - `costsTradePeFinancial`
+#'   - `CCSbounds`
 #'   - `Steel_Production`: Steel production estimates
 #'   - `industry_max_secondary_steel_share`: Maximum share of secondary steel
 #'     production in total steel production and years between which a linear
@@ -12,8 +16,6 @@
 #'     (relative to global average) to which per-capita cement demand converges
 #'   - `ies`
 #'   - `prtp`
-#'   - `CCSbounds`
-#'   - `costsTradePeFinancial`
 #'   - `tradeContsraints`: parameter by Nicolas Bauer (2024) for the region
 #'      specific trade constraints, values different to 1 activate constraints
 #'      and the value is used as effectiveness to varying degrees such as percentage numbers
@@ -27,7 +29,8 @@
 #' @importFrom dplyr bind_rows filter pull select
 #'
 readExpertGuess <- function(subtype) {
-  a <- switch (
+
+  a <- switch(
     subtype,
     "ies"                   = read.csv("ies.csv", sep = ";"),
     "prtp"                  = read.csv("prtp.csv", sep = ";"),
@@ -42,7 +45,7 @@ readExpertGuess <- function(subtype) {
     a$Country <- NULL
     out <- as.magpie(a)
     out[is.na(out)] <- 0
-   }
+  }
 
   if (subtype %in% c("ies", "prtp")) {
     getYears(out) <- "2005"
@@ -118,5 +121,13 @@ readExpertGuess <- function(subtype) {
       as.magpie(datacol = 5)
   }
 
-  out
+  if (subtype == "capacityFactorGlobal") {
+    out <- read.csv("capacity-factors-global_REMIND_3.4.0.csv", sep = ";") %>%
+      as.magpie(datacol = 2)
+  } else if (subtype == "capacityFactorRules") {
+    out <- read.csv("capacity-factor-rules_v1.0.csv", sep = ";") %>%
+      as.magpie(datacol = 4)
+  }
+
+  return(out)
 }

--- a/R/readREMIND_11Regi.R
+++ b/R/readREMIND_11Regi.R
@@ -3,11 +3,10 @@
 #' Read-in an csv files that contains regional data
 #'
 #' @param subtype Name of the regional data, e.g.
-#' "tradecost", "deltacapoffset", "capacityFactorGlobal",
-#' "capacityFactorRules", "taxConvergence", "maxFeSubsidy",
+#' "tradecost", "deltacapoffset", "taxConvergence", "maxFeSubsidy",
 #' "maxPeSubsidy", "propFeSubsidy", "fossilExtractionCoeff", "uraniumExtractionCoeff"
 #' @return magpie object of region dependent data
-#' @author original: not defined, capacity factor, tax, fossil and RLDC changes: Renato Rodrigues
+#' @author original: not defined, tax, fossil and RLDC changes: Renato Rodrigues
 #' @examples
 #' \dontrun{
 #' a <- readSource(type = "REMIND_11Regi", subtype = "tradecost")
@@ -17,8 +16,6 @@ readREMIND_11Regi <- function(subtype) {
     subtype,
     "tradecost"            = read.csv("LueckenDiss_TradeCost.csv", sep = ";", row.names = 1) %>% as.magpie(),
     "deltacapoffset"       = read.csv("p_adj_deltacapoffset_REMIND3.4.0.csv", sep = ";")     %>% as.magpie(datacol = 2),
-    "capacityFactorGlobal" = read.csv("f_cf-global_REMIND_3.4.0.csv", sep = ";")   %>% as.magpie(datacol = 2),
-    "capacityFactorRules"  = read.csv("f_cf-rules_v1.3.csv", sep = ";")            %>% as.magpie(datacol = 4),
     "storageFactor"        = read.csv("storageFactor_REMIND_3.4.0.csv", sep = ";") %>% as.magpie(datacol = 2),
     "taxConvergence"       = read.csv("tax_convergence.csv", sep = ";")            %>% as.magpie(datacol = 4),
     "maxFeSubsidy"         = read.csv("max_FE_subsidy_REMIND_3.5_v1.1.csv", sep = ";") %>% as.magpie(datacol = 4),

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-07-11},
+  date = {2025-07-14},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
   note = {Version: 0.233.3},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.233.2**
+R package **mrremind**, version **0.233.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.233.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.233.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-07-11},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.233.2},
+  note = {Version: 0.233.3},
 }
 ```

--- a/man/convertREMIND_11Regi.Rd
+++ b/man/convertREMIND_11Regi.Rd
@@ -10,7 +10,7 @@ convertREMIND_11Regi(x, subtype)
 \item{x}{MAgPIE object to be converted}
 
 \item{subtype}{Name of the regional data, e.g. tradecost", "pe2se",
-"deltacapoffset", capacityFactorRules", "taxConvergence", "maxFeSubsidy",
+"deltacapoffset", "taxConvergence", "maxFeSubsidy",
 "maxPeSubsidy", "propFeSubsidy", "fossilExtractionCoeff", "uraniumExtractionCoeff"}
 }
 \value{
@@ -19,12 +19,6 @@ A MAgPIE object containing country disaggregated data
 \description{
 Converts REMIND regional data
 }
-\examples{
-
-\dontrun{ a <- convertREMIND_11Regi(x,subtype="capacityFactorGlobal")
-}
-
-}
 \author{
-original: not defined - capacity factor, tax, fossil and RLDC changes: Renato Rodrigues
+original: not defined - tax, fossil and RLDC changes: Renato Rodriguess
 }

--- a/man/readExpertGuess.Rd
+++ b/man/readExpertGuess.Rd
@@ -9,6 +9,10 @@ readExpertGuess(subtype)
 \arguments{
 \item{subtype}{Type of data that should be read.  One of
 \itemize{
+\item \code{capacityFactorGlobal}: Global capacity factors for all REMIND technologies
+\item \code{capacityFactorRules}: Capacity factor rules for selected H12 regions and REMIND technologies
+\item \code{costsTradePeFinancial}
+\item \code{CCSbounds}
 \item \code{Steel_Production}: Steel production estimates
 \item \code{industry_max_secondary_steel_share}: Maximum share of secondary steel
 production in total steel production and years between which a linear
@@ -17,8 +21,6 @@ convergence from historic to target shares is to be applied.
 (relative to global average) to which per-capita cement demand converges
 \item \code{ies}
 \item \code{prtp}
-\item \code{CCSbounds}
-\item \code{costsTradePeFinancial}
 \item \code{tradeContsraints}: parameter by Nicolas Bauer (2024) for the region
 specific trade constraints, values different to 1 activate constraints
 and the value is used as effectiveness to varying degrees such as percentage numbers

--- a/man/readREMIND_11Regi.Rd
+++ b/man/readREMIND_11Regi.Rd
@@ -8,8 +8,7 @@ readREMIND_11Regi(subtype)
 }
 \arguments{
 \item{subtype}{Name of the regional data, e.g.
-"tradecost", "deltacapoffset", "capacityFactorGlobal",
-"capacityFactorRules", "taxConvergence", "maxFeSubsidy",
+"tradecost", "deltacapoffset", "taxConvergence", "maxFeSubsidy",
 "maxPeSubsidy", "propFeSubsidy", "fossilExtractionCoeff", "uraniumExtractionCoeff"}
 }
 \value{
@@ -24,5 +23,5 @@ a <- readSource(type = "REMIND_11Regi", subtype = "tradecost")
 }
 }
 \author{
-original: not defined, capacity factor, tax, fossil and RLDC changes: Renato Rodrigues
+original: not defined, tax, fossil and RLDC changes: Renato Rodrigues
 }


### PR DESCRIPTION
This PR moves capacity factor data from the source `REMIND_11Regi` to `ExpertGuess`
This solves: https://github.com/remindmodel/development_issues/issues/603

Files were moved as follows:

- `f_cf-global_REMIND_3.4.0.csv` -> `capacity-factors-global_REMIND_3.4.0.csv`
- `f_cf-rules_v1.3.csv` -> `capacity-factor-rules_v1.0.csv`

This affects the input data file `f_cf.cs3r`.

As Capacity Factor Rules are no longer in REMIND_11Regi, they are supposed to be reported for H12 Regions now, i.e. `CHN` was converted to `CHA` and `RUS` to `REF`. All other regions are mostly to H12 Regions, although there are some small deviations in EUR and LAM as well.

Deviations in `f_cf.cs3r` > 1% in `f_cf.cs3r`

```
# Largest differences
       fake  year    data        x        y     diff    factor
REF.2   REF y2015 coalchp 0.513705 0.480000 0.033705 0.9343884
REF.3   REF y2020 coalchp 0.556853 0.540000 0.016853 0.9697353
CHA.6   CHA y2015      pc 0.600422 0.590000 0.010422 0.9826422
REF.1   REF y2020      pc 0.529814 0.540000 0.010186 1.0192256
```

