### PR TITLE
Add biochar inputdata

### DIFF
--- a/R/calcBiocharBounds.R
+++ b/R/calcBiocharBounds.R
@@ -1,0 +1,20 @@
+#' Provide price path data
+#'
+#' @author Tabea Dorndorf
+#'
+calcBiocharBounds <- function() {
+  x <- readSource("BiocharData", subtype = "biocharBounds")
+
+  x[is.na(x)] <- 0
+
+  getNames(x) <- NULL
+
+  return(list(
+    x = x,
+    weight = NULL,
+    unit = "t BC/a",
+    description = "Biochar production capacity in 2020 and 2025 by region.
+    Based on data from the European Biochar Market Report 2024/25 and
+    2023 Global Biochar Market Report."
+  ))
+}

--- a/R/calcBiocharPricePath.R
+++ b/R/calcBiocharPricePath.R
@@ -1,0 +1,17 @@
+#' Provide price path data
+#'
+#' @author Tabea Dorndorf
+#'
+calcBiocharPricePath <- function() {
+  x <- readSource("BiocharData", subtype = "biocharPrices")
+
+  return(list(
+    x = x,
+    weight = NULL,
+    unit = "USD 2015/t biochar",
+    description = "Biochar price assumptions over time.
+    Assumptions based on collection of current bulk sale prices
+    (see Dorndorf et al (submitted)).",
+    isocountries = FALSE
+  ))
+}

--- a/R/convertBiocharData.R
+++ b/R/convertBiocharData.R
@@ -1,0 +1,38 @@
+#' Provide price path data
+#'
+#' @author Tabea Dorndorf
+#'
+convertBiocharData <- function(x, subtype) {
+  if(subtype == "biocharBounds"){
+    map0 <- toolGetMapping("regionmappingH12.csv", type = "regional",
+                           where = "mappingfolder")
+
+    weights0 <- readxl::read_xlsx(file.path("BiocharDeploymentData_2411.xlsx"),
+                                  sheet = "EURcountries")
+
+
+    map <- merge(map0, weights0, by = "CountryCode", all.x = TRUE)
+
+    map <- map %>% group_by(RegionCode) %>%
+      mutate(OtherRegionShareCounts = sum(!is.na(data))) %>% ungroup()
+
+    map <- map %>% group_by(RegionCode) %>%
+      mutate(RegionCountTotal = dplyr::n()) %>% ungroup()
+
+    map <- map %>% group_by(RegionCode) %>%
+      mutate(RemainingShare = 1- sum(data, na.rm = TRUE)) %>% ungroup()
+
+    map <- map %>% mutate(RemainingRegionCount = RegionCountTotal - OtherRegionShareCounts) %>%
+      mutate(data2 = RemainingShare * 1/RemainingRegionCount)
+
+    map <- map %>% mutate(data = dplyr::if_else(is.na(data), data2, data))
+
+    weight <- map %>% select(c(CountryCode, data)) %>%
+      as.magpie()
+
+    x <- toolAggregate(x, rel = map0, from = "RegionCode", to = "CountryCode",
+                       weight = weight)
+
+    return(x)
+  }
+}

--- a/R/fullREMIND.R
+++ b/R/fullREMIND.R
@@ -134,6 +134,8 @@ fullREMIND <- function() {
   calcOutput("PotentialWeathering",                   round = 3,  file = "f33_maxProdGradeRegiWeathering.cs3r")
   calcOutput("CostsWeathering",                       round = 8,  file = "p33_transportCostsWeathering.cs4r")
   calcOutput("EEZdistribution",                       round = 4,  file = "p33_EEZdistribution.cs4r")
+  calcOutput("BiocharPricePath",                      round = 2,  file = "p33_BiocharPricePath.cs4r", aggregate = FALSE)
+  calcOutput("BiocharBounds",                         round = 2,  file = "p_boundCapBiochar.cs4r")
   calcOutput("CostsTrade",                            round = 5,  file = "pm_costsPEtradeMp.cs4r")
   calcOutput("CostsTradePeFinancial",                 round = 5,  file = "pm_costsTradePeFinancial.cs3r")
   calcOutput("ShareCHP",                              round = 3,  file = "f32_shCHP.cs4r")

--- a/R/readBiocharData.R
+++ b/R/readBiocharData.R
@@ -1,0 +1,47 @@
+#' Load data for implementation of biochar as magclass object
+#'
+#' Source:
+#' Assumption for REMIND based on data collected in Dorndorf et al (submitted)
+#'
+#' @author Tabea Dorndorf
+#'
+readBiocharData <- function(subtype) {
+
+  # read biochar price data assumptions
+  if (subtype == "biocharPrices") {
+    df <- readxl::read_xlsx(file.path("BiocharPricePaths_v01.xlsx"))
+
+    # convert to magpie object
+    m <- as.magpie(df)
+
+    return(m)
+  }
+
+  # read short-term biochar capacities
+  if (subtype == "biocharBounds") {
+    df <- readxl::read_xlsx(file.path("BiocharDeploymentData_2411.xlsx"),
+                            sheet = "REMINDassumptions")
+
+    # keep only relevant entries
+    df <- df %>% select(c("region", "year", "variable", "data"))
+
+    # keep only entries that have a REMIND region code
+    df <- df[grepl("^[A-Za-z]{3}$", df$region), ]
+
+    # Convert production data to installed capacity assumption
+    capacity_factor <- 0.6  # assumption based on REMIND capacity factors of 0.5-0.65
+    # for those systems with energy co-production
+
+    df <- df %>%
+      mutate(data = dplyr::if_else(variable == "Production",
+                                   data / capacity_factor, data)) %>%
+      mutate(variable = dplyr::if_else(variable == "Production",
+                                       "Installed Capacity", variable))
+
+    # convert to magpie object
+    m <- as.magpie(df)
+    return(m)
+  }
+
+  stop("Not a valid subtype provided to readBiocharData")
+}

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -123,8 +123,6 @@ readExpertGuess <- function(subtype) {
 
   if (subtype == "capacityFactorGlobal") {
     out <- read.csv("capacity-factors-global_REMIND_3.6.0.csv", sep = ";") %>%
-      #out <- read.csv(file.path("C:/PIK/inputdata/sources/ExpertGuess",
-      #                          "capacity-factors-global_REMIND_3.6.0.csv"), sep = ";") %>%
       as.magpie(datacol = 2)
   } else if (subtype == "capacityFactorRules") {
     out <- read.csv("capacity-factor-rules_v1.0.csv", sep = ";") %>%

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -122,7 +122,9 @@ readExpertGuess <- function(subtype) {
   }
 
   if (subtype == "capacityFactorGlobal") {
-    out <- read.csv("capacity-factors-global_REMIND_3.4.0.csv", sep = ";") %>%
+    out <- read.csv("capacity-factors-global_REMIND_3.6.0.csv", sep = ";") %>%
+      #out <- read.csv(file.path("C:/PIK/inputdata/sources/ExpertGuess",
+      #                          "capacity-factors-global_REMIND_3.6.0.csv"), sep = ";") %>%
       as.magpie(datacol = 2)
   } else if (subtype == "capacityFactorRules") {
     out <- read.csv("capacity-factor-rules_v1.0.csv", sep = ";") %>%


### PR DESCRIPTION
This PR adds the inputdata required for biochar production in REMIND, introduced in [PR2168](https://github.com/remindmodel/remind/pull/2168).

Three elements are added: 
- Capacity factors (adjustment in readExpertGuess)
- Biochar price path assumptions (new source file, is an expert guess based on biochar market data collected for Dorndorf et al (submitted))
- Capacity bounds for 2020 and 2025 (new source file, collection from different market reports)