### PR TITLE
IRENA Update to 2025 release

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '48537300'
+ValidationKey: '48559992'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.239.1
-date-released: '2025-07-31'
+version: 0.239.2
+date-released: '2025-08-01'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.239.1
-Date: 2025-07-31
+Version: 0.239.2
+Date: 2025-08-01
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcCapacity.R
+++ b/R/calcCapacity.R
@@ -15,7 +15,7 @@ calcCapacity <- function(subtype) {
 
 
     ###### Use IRENA data for world renewables capacity
-    # Year: 2000-2023
+    # Year: 2000-2024
     mapping <- tibble::tribble(
       ~remind,   ~irena,
       "geohdr",  "Geothermal",
@@ -30,8 +30,8 @@ calcCapacity <- function(subtype) {
       toolAggregate(dim = 3, rel = mapping, from = "irena", to = "remind") * # renaming to remind names
       1e-6 # converting MW to TW
 
-    # Year 2025: use 2023 as a lower-bound
-    getYears(capIRENA) <- gsub("2023", "2025", getYears(capIRENA))
+    # Year 2025: use 2024 as a lower-bound
+    getYears(capIRENA) <- gsub("2024", "2025", getYears(capIRENA))
 
 
     ###### Use Openmod capacity values updated by the LIMES team for the European countries

--- a/R/calcDspvShare.R
+++ b/R/calcDspvShare.R
@@ -1,43 +1,60 @@
-#' Calculates the share of distributed solar pv, wind-onshore/offshore, hydro-small/large from 2015 to 2050. For spv - Only includes grid-connected pv.
-#' @details Known limitations - source for distributed spv (IEA Renewables 2019) is different than source for total spv (IRENA 2019)
-#' @param subtype Either "current","expert", or "irena". Current are current shares extended until 2050. expert is based on Robert P.'s judgement, and irena are based on IRENA's 2050 global numbers. Hydro case remains same in all cases
+#' Calculates the share of DSPV
+#'
+#' Calculates the share of distributed solar pv, wind-onshore/offshore,
+#' hydro-small/large from 2015 to 2050.
+#' For spv - Only includes grid-connected pv.
+#'
+#' @details Known limitations - source for distributed spv (IEA Renewables 2019)
+#' is different than source for total spv (IRENA 2019)
+#'
+#' @param subtype Either "current","expert", or "irena". Current are current
+#' shares extended until 2050. expert is based on Robert P.'s judgement, and
+#' irena are based on IRENA's 2050 global numbers.
+#' Hydro case remains same in all cases
+#'
 #' @author Aman Malik
 #' @return magpie object with REMIND-aggregated regions
 
 calcDspvShare <- function(subtype)
 {
-  # Note: Limitation - Different sources for absolute distributed solar pv (IEA), and absolute total solar pv (IRENA)
-  
-  IRENA_cap <- readSource("IRENA",subtype = "Capacity")
-  
+  # Note: Limitation - Different sources for absolute distributed solar pv (IEA),
+  # and absolute total solar pv (IRENA)
+
+  IRENA_cap <- readSource("IRENA", subtype = "Capacity")
+
   #----------------------------------------
   # solar dpsv and solar utility
-  
+
   dspv <- readSource("IEA_REN")[,2018,] # in GW
   total_spv <- IRENA_cap[,2018,"Solar photovoltaic"]/1000
 
-  # to avoid getting NaN while dividing by total spv capacity, give countries with no spv, a very small value
+  # to avoid getting NaN while dividing by total spv capacity, give
+  # countries with no spv, a very small value
   total_spv[which(total_spv==0),,] <- 0.0001 # in GW
-  
-  
+
+
   if (subtype=="expert"){
     share_spv <- new.magpie(getRegions(dspv),c(2015,2020,2030),names = "spv")
     share_spv[,,] <- dspv/total_spv # 2015 and 2020 get 2018 values
-    # few countries have share greater than 1. This is because either all their solar pv is rooftop (but error exists because of different sources of the numerator and denominator)
-    # or because of disaggregation methodology in readSource(IEA_REN). In any case, these countries don't have significant solar pv installations
-    #  Force it to be 95% but is only for a small number of unimportant countries
+    # few countries have share greater than 1. This is because either all their
+    # solar pv is rooftop (but error exists because of different sources of the
+    # numerator and denominator)
+    # or because of disaggregation methodology in readSource(IEA_REN). In any
+    # case, these countries don't have significant solar pv installations
+
+    # Force it to be 95% but is only for a small number of unimportant countries
     share_spv[which(share_spv[,2015,]>1),,] <- 0.95
     share_spv[which(share_spv[,2020,]>1),,] <- 0.95
-    
-    # for all countries other than IND and JPN, shares are 0.3 in 2030. 
+
+    # for all countries other than IND and JPN, shares are 0.3 in 2030.
     share_spv[,2030,] <- 0.3
     share_spv <- time_interpolate(share_spv,2025,integrate_interpolated_years = T)
-  
+
     # for IND and Japan these are 40% in 2030.
     share_tmp <- share_spv[c("IND","JPN"),c(2015,2020,2030),]
     share_tmp[,2030,] <- 0.4
     share_tmp <- time_interpolate(share_tmp,2025,integrate_interpolated_years = T)
-    
+
     share_spv[c("IND","JPN"),,] <- share_tmp
     # all shares after 2030 until 2050 have same value as 2030
     share_spv <- add_columns(share_spv,addnm = c(2035,2040,2045,2050),dim=2.1)
@@ -46,38 +63,42 @@ calcDspvShare <- function(subtype)
   if (subtype=="current"){
     share_spv <- new.magpie(getRegions(dspv),seq(2015,2050,5),names = "spv")
     share_spv[,,] <- dspv/total_spv
-  
+
   }
-  
+
   if (subtype=="irena"){
     share_spv <- new.magpie(getRegions(dspv),c(2015,2020,2050),names = "spv")
     share_spv[,2015,] <- dspv/total_spv
     share_spv[,2020,] <- dspv/total_spv
-    share_spv[,2050,] <- 0.4 # from IRENA https://irena.org/-/media/Files/IRENA/Agency/Publication/2019/Nov/IRENA_Future_of_Solar_PV_2019.pdf, however these numbers are global 2050. Disaggregate to regions
-    share_spv <- time_interpolate(share_spv,seq(2020,2050,5),integrate_interpolated_years = T)
+    # from IRENA https://irena.org/-/media/Files/IRENA/Agency/Publication/2019/Nov/IRENA_Future_of_Solar_PV_2019.pdf,
+    # however these numbers are global 2050. Disaggregate to regions
+    share_spv[,2050,] <- 0.4
+    share_spv <- time_interpolate(share_spv,
+                                  seq(2020,2050,5),
+                                  integrate_interpolated_years = T)
   }
-  # share of dspv/utilty until 2030 converges to 0.3 linearly except for Japan and India where it is 0.4 
- 
-  
+  # share of dspv/utilty until 2030 converges to 0.3 linearly except for
+  # Japan and India where it is 0.4
+
+
   #-----------------------------------------
-  
+
   #----------------------------
   # Shares - Wind on and offshore
   mapping_remind <- toolGetMapping(getConfig()[1],where = "mappingfolder",type = "regional")
 
   wind_off <- IRENA_cap[,c(2015,2018),"Offshore wind energy"]/1000 # converting to GW
   wind_tot <- IRENA_cap[,c(2015,2018),"Wind"]/1000
-  
+
   # to avoid getting NaN while dividing by total wind capacity, give countries with no wind, a very small value
   wind_tot[which(wind_tot[,2015,]==0),,] <- 0.00001 # in GW
   wind_tot[which(wind_tot[,2018,]==0),,] <- 0.00001 # in GW
-  
-    
+
   # top 20 countries by coastline in CIA's World factbook coastline 2020 - https://www.citypopulation.de/en/world/bymap/Coastlines.html
   top_20 <- c("Canada","Norway","Indonesia","Greenland","Russia","Philippines","Japan","Australia",
               "United States of America","Antarctica","New Zealand","China","Greece","United Kingdom",
               "Mexico","Italy","Brazil","Denmark","Turkey","India")
-  
+
   top_20 <- toolCountry2isocode(top_20)
   # countries with no coastline/landlocked
   no_coast <- c("Monaco","Afghanistan","Andorra","Armenia","Austria","Azerbaijan","Belarus","Bhutan","Bolivia","Botswana",
@@ -85,62 +106,74 @@ calcDspvShare <- function(subtype)
                "Kazakhstan","Kyrgyzstan","Laos","Lesotho","Liechtenstein","Luxembourg","Malawi","Mali",
                "Moldova","Mongolia","Nepal","Niger","North Macedonia","Paraguay","Rwanda","San Marino","Serbia",
                "Slovakia","South Sudan","Switzerland","Tajikistan","Turkmenistan","Uganda","Uzbekistan","Zambia","Zimbabwe")
-  no_coast <- toolCountry2isocode(no_coast)  
+  no_coast <- toolCountry2isocode(no_coast)
   # remaining countries
   rem_countries <- setdiff(mapping_remind$CountryCode,c(top_20,no_coast))
-  # share in 2015 
-  share_wind <- new.magpie(mapping_remind$CountryCode,seq(2015,2050,5),names = "wind")
+  # share in 2015
+  share_wind <- new.magpie(mapping_remind$CountryCode,
+                           seq(2015,2050,5),
+                           names = "wind")
   share_wind[,2015,] <- wind_off[,2015,]/wind_tot[,2015,]
   share_wind[,2020,] <- wind_off[,2018,]/wind_tot[,2018,] # 2020 gets 2018 values
   if (subtype=="expert"){
   # countries with longest coastline have 30% wind share in 2050. Interpolated linearly.
     share_top_20 <- share_wind[top_20,c(2020,2050),]
     share_top_20[,2050,] <- 0.3
-    share_top_20 <- time_interpolate(share_top_20,seq(2020,2050,5),integrate_interpolated_years = T)
+    share_top_20 <- time_interpolate(share_top_20,
+                                     seq(2020,2050,5),
+                                     integrate_interpolated_years = T)
     share_wind[top_20,getYears(share_top_20),] <- share_top_20
     # all other countries with a shore line have 10% wind share in 2050. Interpolated linearly
     share_rem <- share_wind[rem_countries,c(2020,2050),]
     share_rem[,2050,] <- 0.1
-    share_rem <- time_interpolate(share_rem,seq(2025,2045,5),integrate_interpolated_years = T)
+    share_rem <- time_interpolate(share_rem,
+                                  seq(2025,2045,5),
+                                  integrate_interpolated_years = T)
     share_wind[rem_countries,getYears(share_rem),] <- share_rem
-    
+
     share_wind[no_coast,,] <- 0 # landlocked countries
   #share_wind <- mbind(share_wind[no_coast,,],share_top_20,share_rem)
   }
-  
+
   if (subtype=="current"){
   share_wind[,,] <-   wind_off[,2018,]/wind_tot[,2018,]
   share_wind[,2015,] <- wind_off[,2015,]/wind_tot[,2015,]
   }
-  
+
   if (subtype=="irena"){
   share_tmp <- new.magpie(mapping_remind$CountryCode,years = c(2020,2050),names = "wind")
   share_tmp[,"y2020",] <- share_wind[,2020,]
   share_tmp[,"y2050",] <- 0.2
-  share_tmp <- time_interpolate(share_tmp,seq(2025,2045,5),integrate_interpolated_years = T)
-  share_wind[,getYears(share_tmp),] <- share_tmp 
+  share_tmp <- time_interpolate(share_tmp,
+                                seq(2025,2045,5),
+                                integrate_interpolated_years = T)
+  share_wind[,getYears(share_tmp),] <- share_tmp
   share_wind[no_coast,,] <- 0
   }
-  
+
   #-----------------------------------------------------
-  
+
   #---------------------------------
   # Share - hydro small in total hydro (small hydro <10 MW)
   ### From IRENA capacity statistics 2017, for WORLD
   # Total Hydropower capacity (excl. pumped storage and mixed plants) - 1083489 MW
   # Total Hydropower capacity (>10 MW) : 935425 MW
   # Total  Hydropower capacity (<10 MW) : 31277 + 116787 = 148064 MW
-  # share of <10 MW (small) to total capacity:  148064/(935425+148064) = 0.136 
+  # share of <10 MW (small) to total capacity:  148064/(935425+148064) = 0.136
   # share is assumed to be the same world over and remain the same until 2050.
   if (subtype=="current"||subtype=="expert"||subtype=="irena"){
-    share_hydro <- new.magpie(mapping_remind$CountryCode,seq(2015,2050,5),names = "hydro",fill=0.14) # all countries get world average
+    # all countries get world average
+    share_hydro <- new.magpie(mapping_remind$CountryCode,
+                              seq(2015,2050,5),
+                              names = "hydro",
+                              fill=0.14)
   }
   #----------------------------------------
-  
+
   ## Combining all
   share_all <- mbind(share_spv,share_wind,share_hydro)
-  
- 
+
+
   ## Weights
   wt <- IRENA_cap[,"y2018","Total renewable energy"]
 

--- a/R/calcPotentialHydro.R
+++ b/R/calcPotentialHydro.R
@@ -3,7 +3,7 @@
 #' Provides hydro potential data
 #'
 #'
-#' @return hydro potential data and corresonding weights as a list of two
+#' @return hydro potential data and corresponding weights as a list of two
 #' MAgPIE objects
 #' @author Lavinia Baumstark
 #' @seealso \code{\link{readWGBU}}, \code{\link{convertWGBU}}
@@ -25,23 +25,25 @@ calcPotentialHydro <- function() {
   # produced electricity
   #
   # prodElec <- wgbu[,,"Erzeugter Strom(GWh/a)"] / 1000
-  prodElec <- readSource("IRENA","Generation")
-  IRENA_hydro_cap <- readSource("IRENA","Capacity") # in MW
+  prodElec <- readSource("IRENA", "Generation")
+  IRENA_hydro_cap <- readSource("IRENA", "Capacity") # in MW
 
-  # Note: "Hydropower" contains renewable hydropower and mixed hydro plants, but not pure pumped storage
+  # Note: "Hydropower" contains renewable hydropower and mixed hydro plants, but
+  # not pure pumped storage
   prodElec <- prodElec[,2015,"Hydropower"] / 1000
   IRENA_hydro_cap <- IRENA_hydro_cap[,2015,"Hydropower"]
 
-  # ensure that overall potential can produce the generation of 2015, if not set potential to IRENA 2015 generation
+  # ensure that overall potential can produce the generation of 2015, if not set
+  # potential to IRENA 2015 generation
   checkDiff <- new.magpie(getRegions(techPot),NULL,fill = 0)
   for(r in getRegions(techPot)){
-	checkDiff[r,,] <- rowSums(techPot[r,,])-prodElec[r,,]
+	  checkDiff[r,,] <- rowSums(techPot[r,,])-prodElec[r,,]
   }
   # find regions which need adjustment (techPot < prodElec)
   regions <- getRegions(checkDiff[which(checkDiff < 0)])
   # adjust regions
   for(r in regions){
-	techPot[r,,"Technisches Potenzial (TWh/a)"] <- prodElec[r,,]
+	  techPot[r,,"Technisches Potenzial (TWh/a)"] <- prodElec[r,,]
   }
 
   # calculate rest of technical potential (minus installed capacity)
@@ -50,13 +52,16 @@ calcPotentialHydro <- function() {
   restPot[restPot<0] <- 0 #making sure that we do not have negative potentials
 
   # calculate capacity factors for each country
-  # capFac <- setNames(prodElec / wgbu[,,"Derzeit installierte Leistung (MW)"] / 8760 * 1000000, "capacityFactor")
   capFac <- setNames((prodElec / IRENA_hydro_cap) / 8760 * 1000000, "capacityFactor")
+
   # set capacity factor of regions with no installed capacity to 0
   capFac[is.na(capFac)] <- 0
 
   # produced electricity data with grade dimension
-  prodElecGrade <- new.magpie(getRegions(prodElec),getYears(prodElec),c("1","2","3","4","5"),fill=0)
+  prodElecGrade <- new.magpie(getRegions(prodElec),
+                              getYears(prodElec),
+                              c("1","2","3","4","5"),
+                              fill=0)
   for(r in getRegions(prodElec)){
     if(capFac[r,,] > 0.5){
       prodElecGrade[r,,"1"] <- prodElec[r,,]
@@ -77,7 +82,10 @@ calcPotentialHydro <- function() {
   }
 
   # rest of technical potential data with grade dimension
-  restPotGrade  <- new.magpie(getRegions(restPot),getYears(restPot),c("1","2","3","4","5"),fill=0)
+  restPotGrade  <- new.magpie(getRegions(restPot),
+                              getYears(restPot),
+                              c("1","2","3","4","5"),
+                              fill=0)
   # allocate rest potential
   # (number of grades that can be filled depends on the grade of the installed capacity)
   # (3 categories depending on the share of installed capcity to the technical potential)

--- a/R/convertREN21.R
+++ b/R/convertREN21.R
@@ -3,8 +3,9 @@
 #' renewable energy targets into total installed capacity targets (in GW).
 #' @details Policy database accessible in "inputdata/sources/REN21/README"
 #' @param x MAgPIE object to be converted
-#' @param subtype Only "Capacity" asof now
-#' @return Magpie object with Total Installed Capacity targets. The target years differ depending upon the database.
+#' @param subtype Only "Capacity" as of now
+#' @return Magpie object with Total Installed Capacity targets. The target years
+#'         differ depending upon the database.
 #' @author Aman Malik
 #' @importFrom utils read.csv
 #'

--- a/R/readIRENA.R
+++ b/R/readIRENA.R
@@ -15,7 +15,7 @@
 #' @importFrom dplyr mutate rename select case_match relocate
 readIRENA <- function(subtype) {
   # Reading renewables electricity capacity or generation values from xlsx
-  data <- readxl::read_xlsx("2024/IRENA_Stats_Extract_ 2024_H1_V1.xlsx", sheet = "All Data")
+  data <- readxl::read_xlsx("2025/IRENA_Statistics_Extract_2025H2.xlsx", sheet = "Country")
 
   if (subtype == "Capacity") {
     data <- data %>%
@@ -67,7 +67,8 @@ readIRENA <- function(subtype) {
     rename(`Country/area` = "ISO3 code") # keep regional column name of before 9678353
 
   # harmonize Technology names with older version
-  data <- data %>% mutate(Technology = case_match(.data$Technology,
+  data <- data %>%
+    mutate(Technology = case_match(.data$Technology,
     # "Hydropower" contains renewable hydropower and mixed hydro plants, but not pure pumped storage
     "Hydropower (excl. Pumped Storage)"   ~ "Hydropower",
     "Wind energy"                         ~ "Wind",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.239.1**
+R package **mrremind**, version **0.239.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.239.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.239.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-07-31},
+  date = {2025-08-01},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.239.1},
+  note = {Version: 0.239.2},
 }
 ```

--- a/man/calcDspvShare.Rd
+++ b/man/calcDspvShare.Rd
@@ -2,21 +2,27 @@
 % Please edit documentation in R/calcDspvShare.R
 \name{calcDspvShare}
 \alias{calcDspvShare}
-\title{Calculates the share of distributed solar pv, wind-onshore/offshore, hydro-small/large from 2015 to 2050. For spv - Only includes grid-connected pv.}
+\title{Calculates the share of DSPV}
 \usage{
 calcDspvShare(subtype)
 }
 \arguments{
-\item{subtype}{Either "current","expert", or "irena". Current are current shares extended until 2050. expert is based on Robert P.'s judgement, and irena are based on IRENA's 2050 global numbers. Hydro case remains same in all cases}
+\item{subtype}{Either "current","expert", or "irena". Current are current
+shares extended until 2050. expert is based on Robert P.'s judgement, and
+irena are based on IRENA's 2050 global numbers.
+Hydro case remains same in all cases}
 }
 \value{
 magpie object with REMIND-aggregated regions
 }
 \description{
-Calculates the share of distributed solar pv, wind-onshore/offshore, hydro-small/large from 2015 to 2050. For spv - Only includes grid-connected pv.
+Calculates the share of distributed solar pv, wind-onshore/offshore,
+hydro-small/large from 2015 to 2050.
+For spv - Only includes grid-connected pv.
 }
 \details{
-Known limitations - source for distributed spv (IEA Renewables 2019) is different than source for total spv (IRENA 2019)
+Known limitations - source for distributed spv (IEA Renewables 2019)
+is different than source for total spv (IRENA 2019)
 }
 \author{
 Aman Malik

--- a/man/calcPotentialHydro.Rd
+++ b/man/calcPotentialHydro.Rd
@@ -7,7 +7,7 @@
 calcPotentialHydro()
 }
 \value{
-hydro potential data and corresonding weights as a list of two
+hydro potential data and corresponding weights as a list of two
 MAgPIE objects
 }
 \description{

--- a/man/convertREN21.Rd
+++ b/man/convertREN21.Rd
@@ -9,10 +9,11 @@ convertREN21(x, subtype)
 \arguments{
 \item{x}{MAgPIE object to be converted}
 
-\item{subtype}{Only "Capacity" asof now}
+\item{subtype}{Only "Capacity" as of now}
 }
 \value{
-Magpie object with Total Installed Capacity targets. The target years differ depending upon the database.
+Magpie object with Total Installed Capacity targets. The target years
+differ depending upon the database.
 }
 \description{
 This code aggregates and homogenises different types of


### PR DESCRIPTION
One more year of capacities and power generation from IRENA.

Data is used in the following functions:

1. calcCapacity -> capacity, changing 2023 to 2024 ok like this @lecfab?
2. calcCapacityFactorHist -> cap + gen, no change uses 2015 only
3. calcDspvShare -> cap, no changes (except formatting), uses old data only
4. calcIRENA -> no changes needed
5. calcPotentialGeothermal -> cap, uses 2020 value only
6. calcPotentialHydro -> cap + gen, no change uses 2015 only
7. convertNewClimate -> cap + gen, uses 2015 only, should be fine, right @RahelMA?
8. convertREN21 -> cap + gen, uses 2015 only
9. readUNFCCC_NDC -> cap + gen, uses 2015 only, should be fine, right @RahelMA?

Doing a test input-data generation with the updated package and won't merge until it finished successfully.