### PR TITLE
Update IEA CCUS data

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '48559992'
+ValidationKey: '48722400'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.239.2
+version: 0.240.0
 date-released: '2025-08-01'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.239.2
+Version: 0.240.0
 Date: 2025-08-01
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcCCScapacity.R
+++ b/R/calcCCScapacity.R
@@ -4,7 +4,7 @@
 #'
 #' @author Anne Merfort, Falk Benke
 #'
-#' @param subtype either `historical` for data until 2022 or `projections`
+#' @param subtype either `historical` for data until 2024 or `pipeline`
 #' for projections in 2020, 2025 and 2030 (including some redistribution on EU/NEU level)
 #'
 #' @export
@@ -20,7 +20,7 @@ calcCCScapacity <- function(subtype) {
   }
 
   if (subtype == "historical") {
-    # project pipeline snapshot from beginning of 2024
+    # project pipeline snapshot from April 2025
     x <- readSource("IEA_CCUS", subtype = "historical")
   }
 

--- a/R/calcProjectPipelines.R
+++ b/R/calcProjectPipelines.R
@@ -1,8 +1,8 @@
 #' calc Project Pipelines
 #'
 #' Calculate the expected near-term deployment of technologies based on
-#' projects that are currently either being built or in a planning stage
-#' for some technologies multiple sources are available. Output object currently
+#' projects that are currently either being built or in a planning stage.
+#' For some technologies multiple sources are available. Output object currently
 #' needs to contain years 2020, 2025 and 2030.
 #'
 #' Discussions on sources and assumptions:

--- a/R/readIEA_CCUS.R
+++ b/R/readIEA_CCUS.R
@@ -4,7 +4,7 @@
 #'
 #' @author Anne Merfort, Falk Benke
 #'
-#' @param subtype either `historical` for data until 2023,
+#' @param subtype either `historical` for data until 2024,
 #' `projections` for "high" and "low" projections up to 2030 used as input-data
 #'  or `pipeline` separated by status for use in formulating near-term bounds
 #' @importFrom dplyr filter mutate select
@@ -16,55 +16,90 @@ readIEA_CCUS <- function(subtype) {
   # project types filter applied to source
   projectTypes <- c("Full chain", "Storage", "T&S")
 
-  data <- readxl::read_excel("IEA CCUS Projects Database 2024.xlsx",
+  data <- readxl::read_excel("IEA CCUS Projects Database 2025.xlsx",
     sheet = "CCUS Projects Database"
   ) %>%
     select(
       "project" = "Project name",
-      "country" = "Country",
+      "country" = "Country or economy",
       "type" = "Project type",
       "start" = "Operation",
-      "end" = "Suspension/decommissioning",
+      "end" = "Suspension/decommissioning/cancellation",
       "status" = "Project Status",
       "value" = "Estimated capacity by IEA (Mt CO2/yr)"
     ) %>%
     # remove entries without announced capacities and not matching project type
     filter(!is.na(.data$value), .data$type %in% projectTypes)
 
-  # manually assign shared project(s) to one (currently: first) country
-  data[data$project == "EU2NSEA", "country"] <- "Norway"
-  data[data$country == "Japan-unknown", "country"] <- "Japan"
-
-  # correct typo in IEA Data
+  # correct mistakes in IEA Data
   data[data$country == "Lybia", "country"] <- "Libya"
+  data[data$country == "Island", "country"] <- "Iceland"
+
+
+  # new shared projects:
+  # - United States-Canada,
+  # - Netherlands-Belgium,
+  # - Australia-Timor Leste,
+  # - France-Spain,
+  # - Japan-Australia
 
   # share capacities of projects by multiple countries according to their GDP
   gdp <- calcOutput("GDP", scenario = "SSP2", aggregate = FALSE)
   gdp_JPN <- as.numeric(gdp["JPN", 2020, ])
   gdp_AUS <- as.numeric(gdp["AUS", 2020, ])
   gdp_MYS <- as.numeric(gdp["MYS", 2020, ])
+  gdp_USA <- as.numeric(gdp["USA", 2020, ])
+  gdp_CAN <- as.numeric(gdp["CAN", 2020, ])
+  gdp_NLD <- as.numeric(gdp["NLD", 2020, ])
+  gdp_BEL <- as.numeric(gdp["BEL", 2020, ])
+  gdp_TLS <- as.numeric(gdp["TLS", 2020, ])
+  gdp_FRA <- as.numeric(gdp["FRA", 2020, ])
+  gdp_ESP <- as.numeric(gdp["ESP", 2020, ])
 
   JM <- data[data$country == "Japan-Malaysia", ]
-  AJ <- data[data$country == "Australia-Japan", ]
+  AJ <- data[data$country %in% c("Australia-Japan", "Japan-Australia"), ]
+  UC <- data[data$country == "United States-Canada", ]
+  NB <- data[data$country == "Netherlands-Belgium", ]
+  AT <- data[data$country == "Australia-Timor Leste", ]
+  FS <- data[data$country == "France-Spain", ]
 
   # remove mixed-country data and attach single country data weighted by GDP
   data <- data %>%
-    filter(!.data$country %in% c("Japan-Malaysia", "Australia-Japan")) %>%
+    filter(!.data$country %in% c("Japan-Malaysia",
+                                 "Australia-Japan",
+                                 "Japan-Australia",
+                                 "United States-Canada",
+                                 "Netherlands-Belgium",
+                                 "Australia-Timor Leste",
+                                 "France-Spain")) %>%
     rbind(
     mutate(JM, country = "Japan",     value = .data$value*gdp_JPN/(gdp_JPN + gdp_MYS)),
     mutate(JM, country = "Malaysia",  value = .data$value*gdp_MYS/(gdp_JPN + gdp_MYS)),
+
     mutate(AJ, country = "Australia", value = .data$value*gdp_AUS/(gdp_JPN + gdp_AUS)),
-    mutate(AJ, country = "Japan",     value = .data$value*gdp_JPN/(gdp_JPN + gdp_AUS))
+    mutate(AJ, country = "Japan",     value = .data$value*gdp_JPN/(gdp_JPN + gdp_AUS)),
+
+    mutate(UC, country = "United States", value = .data$value*gdp_USA/(gdp_USA + gdp_CAN)),
+    mutate(UC, country = "Canada",        value = .data$value*gdp_CAN/(gdp_USA + gdp_CAN)),
+
+    mutate(NB, country = "Netherlands", value = .data$value*gdp_NLD/(gdp_NLD + gdp_BEL)),
+    mutate(NB, country = "Belgium",     value = .data$value*gdp_BEL/(gdp_NLD + gdp_BEL)),
+
+    mutate(AT, country = "Australia",   value = .data$value*gdp_AUS/(gdp_AUS + gdp_TLS)),
+    mutate(AT, country = "Timor Leste", value = .data$value*gdp_TLS/(gdp_AUS + gdp_TLS)),
+
+    mutate(FS, country = "France", value = .data$value*gdp_FRA/(gdp_FRA + gdp_ESP)),
+    mutate(FS, country = "Spain",  value = .data$value*gdp_ESP/(gdp_FRA + gdp_ESP))
     )
 
   if (subtype == "historical") {
     hist <- data %>%
-      filter(.data$start <= 2023,
-             .data$status != "Suspended/cancelled/decommissioned")
+      filter(.data$start <= 2024, .data$status != "Cancelled")
     # ASSUMPTION: if no end year is given, assume project remains active at
     # least until present
-    hist[is.na(hist$end), "end"] <- 2023
+    hist[is.na(hist$end), "end"] <- 2024
 
+    # expand data from start-end format to yearly capacity
     tmp <- NULL
     for (i in seq_len(nrow(hist))) {
       tmp <- rbind(
@@ -76,8 +111,9 @@ readIEA_CCUS <- function(subtype) {
       )
     }
 
+    # summation of projects to get country totals
     cap <- stats::aggregate(value ~ country + period, data = tmp, FUN = sum) %>%
-      filter(.data$period <= 2023) %>%
+      filter(.data$period <= 2024) %>%
       mutate(variable = "Carbon Management|Storage")
 
     cap <- cap[, c("country", "period", "variable", "value")]
@@ -90,7 +126,7 @@ readIEA_CCUS <- function(subtype) {
     proj <- data %>%
       mutate(
         "start" = ifelse(is.na(.data$start), 2030, .data$start),
-        "end" = ifelse(is.na(.data$end), 2030, .data$end)
+        "end"   = ifelse(is.na(.data$end),   2030, .data$end)
       ) %>%
     # remove entries where suspension is before operation or in same year
     filter(.data$start < .data$end)
@@ -141,7 +177,7 @@ readIEA_CCUS <- function(subtype) {
       # remove entries where suspension is before operation or in same year
       filter(.data$start < .data$end) %>%
       # remove cancelled projects
-      filter(.data$status != "Suspended/cancelled/decommissioned")
+      filter(.data$status != "Cancelled")
 
     # convert to data.frame with yearly active capacities
     tmp <- NULL
@@ -177,7 +213,7 @@ readIEA_CCUS <- function(subtype) {
     cap <- rbind(capOp, capCon, capPlan) %>%
       mutate(variable = "Carbon Management|Storage")
     cap <- cap[, c("country", "period", "variable", "status", "value")]
-    x <- as.magpie(cap, spatial = 1)
+    x <- as.magpie(cap, spatial = "country")
 
   } else {
     stop("Invalid subtype. Must be either

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.239.2**
+R package **mrremind**, version **0.240.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.239.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.240.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-08-01},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.239.2},
+  note = {Version: 0.240.0},
 }
 ```

--- a/man/calcCCScapacity.Rd
+++ b/man/calcCCScapacity.Rd
@@ -7,7 +7,7 @@
 calcCCScapacity(subtype)
 }
 \arguments{
-\item{subtype}{either \code{historical} for data until 2022 or \code{projections}
+\item{subtype}{either \code{historical} for data until 2024 or \code{pipeline}
 for projections in 2020, 2025 and 2030 (including some redistribution on EU/NEU level)}
 }
 \description{

--- a/man/calcProjectPipelines.Rd
+++ b/man/calcProjectPipelines.Rd
@@ -12,8 +12,8 @@ calcProjectPipelines(subtype)
 }
 \description{
 Calculate the expected near-term deployment of technologies based on
-projects that are currently either being built or in a planning stage
-for some technologies multiple sources are available. Output object currently
+projects that are currently either being built or in a planning stage.
+For some technologies multiple sources are available. Output object currently
 needs to contain years 2020, 2025 and 2030.
 }
 \details{

--- a/man/readIEA_CCUS.Rd
+++ b/man/readIEA_CCUS.Rd
@@ -7,7 +7,7 @@
 readIEA_CCUS(subtype)
 }
 \arguments{
-\item{subtype}{either \code{historical} for data until 2023,
+\item{subtype}{either \code{historical} for data until 2024,
 \code{projections} for "high" and "low" projections up to 2030 used as input-data
 or \code{pipeline} separated by status for use in formulating near-term bounds}
 }


### PR DESCRIPTION
Using release from April 2025.

This affects REMIND input data, the historical.mif and the threshold.mif. Running all functions touched by this locally worked out fine after resolving a few additional data cleaning tasks. Input data generation is underway.