### PR TITLE
Update IAEA PRIS nuclear project database

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '48754706'
+ValidationKey: '48779816'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.240.1
-date-released: '2025-08-06'
+version: 0.240.2
+date-released: '2025-08-08'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.240.1
-Date: 2025-08-06
+Version: 0.240.2
+Date: 2025-08-08
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcProjectPipelines.R
+++ b/R/calcProjectPipelines.R
@@ -193,25 +193,25 @@ calcProjectPipelines <- function(subtype) {
   # Nuclear ----
   } else if (subtype == "nuclear") {
     # Source 1: GEM
-    x <- readSource("GlobalEnergyMonitor")
-    x <- x[, , "Nuclear", pmatch = T]
-
-    # initialize magclass object for thresholds
-    t <- new.magpie(getRegions(x),
-                    c(2020, 2025, 2030),
-                    c("GlobalEnergyMonitor.Cap|Electricity|Nuclear.min_red.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Nuclear.min_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Nuclear.max_yel.GW",
-                      "GlobalEnergyMonitor.Cap|Electricity|Nuclear.max_red.GW"),
-                    sets = getSets(x))
-
-    # ASSUMPTION: min_yel (only one project in Belarus with start date)
-    t[, , "min_yel"] <- x[, , "operating"]*0.8
-
-    # no max_yel, max_red -> would probably make sense to use construction also
-    # without start date, otherwise very low upper bounds
-
-    x <- mbind(x, t)
+    # x <- readSource("GlobalEnergyMonitor")
+    # x <- x[, , "Nuclear", pmatch = T]
+    #
+    # # initialize magclass object for thresholds
+    # t <- new.magpie(getRegions(x),
+    #                 c(2020, 2025, 2030),
+    #                 c("GlobalEnergyMonitor.Cap|Electricity|Nuclear.min_red.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Nuclear.min_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Nuclear.max_yel.GW",
+    #                   "GlobalEnergyMonitor.Cap|Electricity|Nuclear.max_red.GW"),
+    #                 sets = getSets(x))
+    #
+    # # ASSUMPTION: min_yel (only one project in Belarus with start date)
+    # t[, , "min_yel"] <- x[, , "operating"]*0.8
+    #
+    # # no max_yel, max_red -> would probably make sense to use construction also
+    # # without start date, otherwise very low upper bounds
+    #
+    # x <- mbind(x, t)
 
     # Source 2: IAEA PRIS
     # doesn't contain dates for expected start of operation
@@ -250,7 +250,7 @@ calcProjectPipelines <- function(subtype) {
     y <- mbind(y, t)
 
     # combine data from both sources
-    x <- mbind(x, y)
+    x <- y  # mbind(x, y)
 
     # meta data
     unit <- "GW"

--- a/R/fullTHRESHOLDS.R
+++ b/R/fullTHRESHOLDS.R
@@ -181,7 +181,7 @@ fullTHRESHOLDS <- function(type = "config") {
   getItems(out, dim = 1) <- gsub("GLO", "World", getItems(out, dim = 1))
 
   # remove GEM as it is not up to date and shouldn't be used in this state
-  out <- out[, , "GlobalEnergyMonitor", invert = TRUE]
+  # out <- out[, , "GlobalEnergyMonitor", invert = TRUE]
 
   # export to file ----
   if (type == "full") {

--- a/R/readIAEA_PRIS.R
+++ b/R/readIAEA_PRIS.R
@@ -10,7 +10,7 @@
 readIAEA_PRIS <- function() {
   # only information given is what is currently operating and what is under
   # construction (without start date). all calculations are about 2030 estimates
-  x <- readxl::read_xlsx("nuclear_capacities_20240716.xlsx") %>%
+  x <- readxl::read_xlsx("nuclear_capacities_20250808.xlsx") %>%
     mutate("operational"  = .data$operational,
            "construction" = .data$construction,
            "inactive"     = .data$inactive,  # only relevant for Japan

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.240.1**
+R package **mrremind**, version **0.240.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.240.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.240.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-08-06},
+  date = {2025-08-08},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.240.1},
+  note = {Version: 0.240.2},
 }
 ```


### PR DESCRIPTION
Updated the numbers from the IAEA PRIS Website that is being used to arrive at near-term estimates for nuclear capacities in 2030. For more details see the documentation here: https://github.com/pik-piam/mrremind/discussions/540

Also removes some code reading in data from the Global Energy Monitor as it currently isn't useful.