### PR TITLE
remove industry expert guesses

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '488071597'
+ValidationKey: '488115936'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.240.11
-date-released: '2025-08-27'
+version: 0.240.12
+date-released: '2025-08-28'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.240.11
-Date: 2025-08-27
+Version: 0.240.12
+Date: 2025-08-28
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readExpertGuess.R
+++ b/R/readExpertGuess.R
@@ -22,13 +22,6 @@
 #'      constraints, values different to 1 activate constraints and the value is used as
 #'      effectiveness to varying degrees such as percentage numbers (Nicolas Bauer)
 #'
-#'   - `Steel_Production`: Steel production estimates (Michaja Pehl)
-#'   - `industry_max_secondary_steel_share`: Maximum share of secondary steel
-#'     production in total steel production and years between which a linear
-#'     convergence from historic to target shares is to be applied. (Michaja Pehl)
-#'   - `cement_production_convergence_parameters`: convergence year and level
-#'     (relative to global average) to which per-capita cement demand converges (Michaja Pehl)
-#'
 #' @return magpie object of the data
 #' @author Lavinia Baumstark, Falk Benke
 #' @examples
@@ -110,52 +103,6 @@ readExpertGuess <- function(subtype) {
 
     out <- read.csv("tradeConstraints.csv", sep = ";") %>%
       as.magpie()
-  }
-
-  # expert guesses used in mrindustry ----
-
-  if (subtype == "Steel_Production") {
-    out <- readr::read_csv(
-      file = "Steel_Production.csv",
-      comment = "#",
-      show_col_types = FALSE
-    ) %>%
-      quitte::madrat_mule()
-  }
-
-  if (subtype == "industry_max_secondary_steel_share") {
-    out <- readr::read_csv(
-      file = "industry_max_secondary_steel_share.csv",
-      comment = "#",
-      show_col_types = FALSE
-    ) %>%
-      quitte::madrat_mule()
-  }
-
-  if (subtype == "cement_production_convergence_parameters") {
-    out <- readr::read_csv(
-      file = "cement_production_convergence_parameters.csv",
-      col_types = "cdi",
-      comment = "#"
-    )
-
-    out <- bind_rows(
-      out %>%
-        filter(!is.na(.data$region)),
-      out %>%
-        utils::head(n = 1) %>%
-        filter(is.na(.data$region)) %>%
-        select(-"region") %>%
-        tidyr::expand_grid(region = toolGetMapping(
-          name = "regionmapping_21_EU11.csv",
-          type = "regional", where = "mappingfolder"
-        ) %>%
-          pull("RegionCode") %>%
-          unique() %>%
-          sort() %>%
-          setdiff(out$region))
-    ) %>%
-      quitte::madrat_mule()
   }
 
   return(out)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.240.11**
+R package **mrremind**, version **0.240.12**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.240.11, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.240.12, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-08-27},
+  date = {2025-08-28},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.240.11},
+  note = {Version: 0.240.12},
 }
 ```

--- a/man/convertExpertGuess.Rd
+++ b/man/convertExpertGuess.Rd
@@ -28,12 +28,6 @@ export and use) (Nicolas Bauer)
 \item \code{tradeConstraints}: parameter by Nicolas Bauer (2024) for the region specific trade
 constraints, values different to 1 activate constraints and the value is used as
 effectiveness to varying degrees such as percentage numbers (Nicolas Bauer)
-\item \code{Steel_Production}: Steel production estimates (Michaja Pehl)
-\item \code{industry_max_secondary_steel_share}: Maximum share of secondary steel
-production in total steel production and years between which a linear
-convergence from historic to target shares is to be applied. (Michaja Pehl)
-\item \code{cement_production_convergence_parameters}: convergence year and level
-(relative to global average) to which per-capita cement demand converges (Michaja Pehl)
 }}
 }
 \description{

--- a/man/readExpertGuess.Rd
+++ b/man/readExpertGuess.Rd
@@ -26,12 +26,6 @@ export and use) (Nicolas Bauer)
 \item \code{tradeConstraints}: parameter by Nicolas Bauer (2024) for the region specific trade
 constraints, values different to 1 activate constraints and the value is used as
 effectiveness to varying degrees such as percentage numbers (Nicolas Bauer)
-\item \code{Steel_Production}: Steel production estimates (Michaja Pehl)
-\item \code{industry_max_secondary_steel_share}: Maximum share of secondary steel
-production in total steel production and years between which a linear
-convergence from historic to target shares is to be applied. (Michaja Pehl)
-\item \code{cement_production_convergence_parameters}: convergence year and level
-(relative to global average) to which per-capita cement demand converges (Michaja Pehl)
 }}
 }
 \value{


### PR DESCRIPTION
This removes no more used expert guesses that were moved to mrindustry.

See also
https://github.com/pik-piam/mrindustry/pull/58
https://github.com/pik-piam/mrremind/issues/728