### PR TITLE
Minor fix: Allow zero weights in calcGAINS2025 and ensure correct region ordering

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '49237320'
+ValidationKey: '49280434'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.242.0
-date-released: '2025-09-15'
+version: 0.242.2
+date-released: '2025-09-16'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.242.0
-Date: 2025-09-15
+Version: 0.242.2
+Date: 2025-09-16
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcGAINS2025.R
+++ b/R/calcGAINS2025.R
@@ -12,7 +12,7 @@
 #' @param weight_source Source of air pollutant reference emissions in 2020 that
 #'         is used to derive the weights ("CEDS2025" or "GAINS2025")
 #' @param outsectors Output sectoral aggregation ("GAINS2025" or "REMIND")
-#' @param outunit Output unit for emission factors ("Mt/PJ" or "Tg/TWa")
+#' @param outunit Output unit for emission factors ("kt/PJ" or "Tg/TWa")
 #' @author Gabriel Abrahao, Laurin Koehler-Schindler
 #' @importFrom utils tail head
 
@@ -22,7 +22,7 @@ calcGAINS2025 <- function(weight_source = "CEDS2025", outsectors = "GAINS2025", 
   # ==============================================================================
 
   # conversion factors
-  conv_Mt_per_PJ_to_Tg_per_TWa <- (1e12 * (365 * 24 * 60 * 60)) / 1e15
+  conv_kt_per_PJ_to_Tg_per_TWa <-   1e-3* (1e12 * (365 * 24 * 60 * 60)) / 1e15
 
   # GAINS timesteps
   # historical
@@ -404,6 +404,7 @@ calcGAINS2025 <- function(weight_source = "CEDS2025", outsectors = "GAINS2025", 
     from = "gainscode", to = "CountryCode",
     weight = NULL, dim = 1, wdim = NULL
   )
+  isoefs <- magpiesort(isoefs)
 
   # C. Add weights ===============================================================
 
@@ -450,8 +451,8 @@ calcGAINS2025 <- function(weight_source = "CEDS2025", outsectors = "GAINS2025", 
 
   if (outunit == "Tg/TWa") {
     # Convert unit
-    isoefs <- isoefs * conv_Mt_per_PJ_to_Tg_per_TWa
-  } else if (outunit == "Mt/PJ") {
+    isoefs <- isoefs * conv_kt_per_PJ_to_Tg_per_TWa
+  } else if (outunit == "kt/PJ or kt/Mt") {
     # Already in correct unit
   } else {
     stop(paste0("Unknown unit: ", outunit))
@@ -468,8 +469,8 @@ calcGAINS2025 <- function(weight_source = "CEDS2025", outsectors = "GAINS2025", 
   } else if (outsectors == "REMIND") {
     # SO2 unit conversion =======================================================
     # Apparently REMIND expects TgS internally, but not in exoGAINS
-    conv_MtSO2_to_MtS <- 1 / 2 # 32/(32+2*16)
-    isoefs[, , "SO2"] <- isoefs[, , "SO2"] * conv_MtSO2_to_MtS
+    conv_ktSO2_to_ktS <- 1 / 2 # 32/(32+2*16)
+    isoefs[, , "SO2"] <- isoefs[, , "SO2"] * conv_ktSO2_to_ktS
 
     # Rename and change order subdimensions =====================================
     fixDims <- function(mag) {
@@ -536,6 +537,7 @@ calcGAINS2025 <- function(weight_source = "CEDS2025", outsectors = "GAINS2025", 
     x = out,
     weight = wgt,
     unit = outunit,
-    description = "Emission factor timeseries for all scenarios and for all REMIND timesteps based on GAINS2025 data."
+    description = "Emission factor timeseries for all scenarios and for all REMIND timesteps based on GAINS2025 data.",
+    aggregationArguments = list(zeroWeight = "allow")
   ))
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.242.0**
+R package **mrremind**, version **0.242.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.242.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G (2025). "mrremind: MadRat REMIND Input Data Package." Version: 0.242.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao},
-  date = {2025-09-15},
+  date = {2025-09-16},
   year = {2025},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.242.0},
+  note = {Version: 0.242.2},
 }
 ```

--- a/man/calcGAINS2025.Rd
+++ b/man/calcGAINS2025.Rd
@@ -17,7 +17,7 @@ is used to derive the weights ("CEDS2025" or "GAINS2025")}
 
 \item{outsectors}{Output sectoral aggregation ("GAINS2025" or "REMIND")}
 
-\item{outunit}{Output unit for emission factors ("Mt/PJ" or "Tg/TWa")}
+\item{outunit}{Output unit for emission factors ("kt/PJ" or "Tg/TWa")}
 }
 \value{
 Emission factor timeseries for all scenarios from 2005 to 2100:


### PR DESCRIPTION
Three minor fixes as follow-up of #731:

1. Actively allow zero weights in calcGAINS2025.
2. Apply magpiesort to isoefs in calcGAINS2025 to bring ISO countries in alphabetical order. This does not change the output of the function as madrat recognizes it. So only an aesthetic fix.
3. Switch unit of emission factors to kt emissions / PJ or Mt activity (previously Mt emissions). This is to keep the same units for REMIND in comparison with `calcGAINS2025forREMIND`.