### PR TITLE
Fix NDC emissions target calculation for China, EU and Japan

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '54436300'
+ValidationKey: '54512513'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.265.0
-date-released: '2026-03-30'
+version: 0.265.1
+date-released: '2026-04-20'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.265.0
-Date: 2026-03-30
+Version: 0.265.1
+Date: 2026-04-20
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcEmiTargetReference.R
+++ b/R/calcEmiTargetReference.R
@@ -52,11 +52,25 @@ calcEmiTargetReference <- function() {
     "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"
   )]
 
+
+  # manually add data from UNFCCC GHG Profiles for China
+  # https://di.unfccc.int/ghg_profile_non_annex1
+  # This is what China official reported as their reference year emissions for the 2030 NDC target.
+  # We use total GHG emissions here although the emissions intensity 2030 target only refers to CO2 emissions.
+  # This is because we lack a projection of non-CO2 emissions development until 2030.
+  # We therefore calculate the target based on GHG-intensity, not CO2-intensity.
+  # The difference should not be large but the target should be a bit more ambitious than the actual CO2-intensity target.
+  ghgUNFCCC["CHN", "y2005", "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] <- 7249
+  ghgUNFCCC["CHN", "y2005", "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)"] <- -766
+
   ghgUNFCCC <- add_columns(ghgUNFCCC, "Emi|GHG|w/o Bunkers|w/o Land-Use Change (Mt CO2eq/yr)", dim = 3.1)
 
   ghgUNFCCC[, , "Emi|GHG|w/o Bunkers|w/o Land-Use Change (Mt CO2eq/yr)"] <-
     ghgUNFCCC[, , "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] -
     ghgUNFCCC[, , "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)"]
+
+
+
 
   # merge CEDS and UNFCCCC values ----
 
@@ -64,6 +78,9 @@ calcEmiTargetReference <- function() {
     getItems(unfccc, dim = 1),
     getItems(readSource("UNFCCC", convert = FALSE), dim = 1)
   )
+
+  # also take China from UNFCCC as data from GHG profile was manually entered above
+  unfcccReg <- c(unfcccReg,"CHN")
 
   out <- ghgCEDS
   out[unfcccReg, , ] <- ghgUNFCCC[unfcccReg, , ]

--- a/R/calcEmiTargetReference.R
+++ b/R/calcEmiTargetReference.R
@@ -63,6 +63,13 @@ calcEmiTargetReference <- function() {
   ghgUNFCCC["CHN", "y2005", "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] <- 7249
   ghgUNFCCC["CHN", "y2005", "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)"] <- -766
 
+  # Also take India 2005 reference year from UNFCCC GHG Profile
+  # this is the average of 2000 and 2010 emissions as 2005 was not reported
+  ghgUNFCCC["IND", "y2005", "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] <- 1593
+  ghgUNFCCC["IND", "y2005", "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)"] <- -237
+
+
+
   ghgUNFCCC <- add_columns(ghgUNFCCC, "Emi|GHG|w/o Bunkers|w/o Land-Use Change (Mt CO2eq/yr)", dim = 3.1)
 
   ghgUNFCCC[, , "Emi|GHG|w/o Bunkers|w/o Land-Use Change (Mt CO2eq/yr)"] <-
@@ -79,8 +86,8 @@ calcEmiTargetReference <- function() {
     getItems(readSource("UNFCCC", convert = FALSE), dim = 1)
   )
 
-  # also take China from UNFCCC as data from GHG profile was manually entered above
-  unfcccReg <- c(unfcccReg,"CHN")
+  # also take China and India from UNFCCC as data from GHG profile was manually entered above
+  unfcccReg <- c(unfcccReg,"CHN","IND")
 
   out <- ghgCEDS
   out[unfcccReg, , ] <- ghgUNFCCC[unfcccReg, , ]

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -192,7 +192,7 @@ readUNFCCC_NDC <- function(subtype, subset) {
       # https://www.climatechangenews.com/2026/03/25/india-sets-achievable-green-electricity-and-emissions-instensity-targets/
       majorE <- majorE %>%
         rbind(majorE %>%
-                filter(ISO_Code == "IND") %>%
+                filter(.data$ISO_Code == "IND") %>%
                 mutate(Target_Year = 2035,
                        `Unconditional Relative` = -0.47,
                        `Conditional Relative` = -0.47))

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -169,37 +169,47 @@ readUNFCCC_NDC <- function(subtype, subset) {
         c("BAU_or_Reference_emissions_in_MtCO2e", "LULUCF")
       ] <-
         list(0.944, "Excluding")
-      
+
       # China 2035 this target is including LULUCF emissions
       # peak year =2025
       # reference emissions in 2025:
       # from REMIND_2026_01_22 NPi2025;Emi|GHG|w/o Bunkers|w/o Land-Use Change in  2025= 16079
       # LULUCF in 2020= -1211.589 in 2030= -935 thus we assume -1000 in 2025
-      
+
       majorE[
         majorE$ISO_Code == "CHN" & majorE$Target_Year == 2035,
         c("Reference_Year", "BAU_or_Reference_emissions_in_MtCO2e")
       ] <-
         list("BAU", 15500)
-      
+
       # Saudi Arabia still wrong it is 2019 instead of BAU
       majorE[
         majorE$ISO_Code == "SAU",
         "Reference_Year"
       ] <- "2019"
-      
+
+      # For Japan, use reference emissions from sheet for base year, not CEDS data.
+      # This includes the reference emissions that Japan actually reported to calculate its NDC targets.
+      majorE[
+        majorE$ISO_Code == "JPN",
+        "Reference_Year"
+      ] <- "-1"
+
+
+      # end: manual corrections
+
       PBL_majorE <- majorE
-      
+
       majorISO <- unique(PBL_majorE$ISO_Code)
-      
-      
+
+
       EUR_NDC_countries <- c(
         "POL", "CZE", "ROU", "BGR", "HUN", "SVK", "LTU", "EST", "SVN",
         "LVA", "DEU", "FRA", "ITA", "ESP", "NLD", "BEL", "GRC", "AUT",
         "PRT", "FIN", "SWE", "IRL", "DNK", "LUX", "CYP", "MLT", "JEY",
         "FRO", "GIB", "GGY", "IMN", "HRV", "GBR"
       )
-      
+
       PBL_NDCs <- readxl::read_excel(
         PBLtargets,
         sheet = "NDC emission levels", skip = 2, progress = FALSE

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -188,13 +188,20 @@ readUNFCCC_NDC <- function(subtype, subset) {
         "Reference_Year"
       ] <- "2019"
 
-      # For Japan, use reference emissions from sheet for base year, not CEDS data.
-      # This includes the reference emissions that Japan actually reported to calculate its NDC targets.
-      majorE[
-        majorE$ISO_Code == "JPN",
-        "Reference_Year"
-      ] <- "-1"
+      # add latest India 2035 target annoucement of -47% GHG/GDP
+      # https://www.climatechangenews.com/2026/03/25/india-sets-achievable-green-electricity-and-emissions-instensity-targets/
+      majorE <- majorE %>%
+        rbind(majorE %>%
+                filter(ISO_Code == "IND") %>%
+                mutate(Target_Year = 2035,
+                       `Unconditional Relative` = -0.47,
+                       `Conditional Relative` = -0.47))
 
+      # interpret India emissions intensity targets as excl. LULUCF
+      majorE[
+        majorE$ISO_Code == "IND",
+        "LULUCF"
+      ] <- "Excluding"
 
       # end: manual corrections
 

--- a/R/toolCalcGhgTarget.R
+++ b/R/toolCalcGhgTarget.R
@@ -71,34 +71,45 @@ toolCalcGhgTarget <- function(x, subtype, subset) {
       # 2. Type-GHG-relative: relative reduction of emissions. E.g., "9% reduction compared to base year or BAU"
     } else if (allowedType[data[regi, year, "Type"]] == "GHG") { # relative GHG change
 
-      if (data[regi, year, "Reference_Year"] == -1) { # -1 if BAU.
-        if (!is.na(data[regi, year, "BAU_or_Reference_emissions_in_MtCO2e"])) {
-          # target * BAU emissions in sheet
-          ghgTarget <- (1 + data[regi, year, conditional]) *
-            data[regi, year, "BAU_or_Reference_emissions_in_MtCO2e"]
-        } else {
-          message("For ", regi, " in ", year, ", reference year is BAU, but BAU Emissions are missing.")
+      # 1. Prefer BAU or reference emissions from sheet if available
+      if (!is.na(data[regi, year, "BAU_or_Reference_emissions_in_MtCO2e"])) {
+
+        ghgTarget <- (1 + data[regi, year, conditional]) *
+          data[regi, year, "BAU_or_Reference_emissions_in_MtCO2e"]
+
+      } else {
+
+        # 2. Fall back to historical reference year if no reference emissions from sheet
+
+        # if target relative to BAU
+        if (data[regi, year, "Reference_Year"] == -1) {
+          message("For ", regi, " in ", year,
+                  ", BAU emissions missing and no valid reference year provided.")
           return(ghgTarget)
         }
-      } else { # then Reference_Year contains a year
-
-        # target * historic GHG emissions from CEDS (best fit)
 
         histYear <- min(
           data[regi, year, "Reference_Year"],
           max(getYears(ghg[, c(2030, 2035), , invert = TRUE], as.integer = TRUE))
         )
 
-        if (data[regi, year, "Reference_Year"] > max(getYears(ghg, as.integer = TRUE))) {
+        # if target relative to reference year
+        if (data[regi, year, "Reference_Year"] >
+            max(getYears(ghg, as.integer = TRUE))) {
+
           message(
-            "For ", regi, " in ", year, ", reference year ", data[regi, year, "Reference_Year"][1],
-            " is above ", max(getYears(ghg, as.integer = TRUE)), ", so we use the latter as reference year."
+            "For ", regi, " in ", year,
+            ", reference year ", data[regi, year, "Reference_Year"][1],
+            " is above ", max(getYears(ghg, as.integer = TRUE)),
+            ", so we use the latter as reference year."
           )
         }
 
         ghgTarget <- (1 + data[regi, year, conditional]) *
           setYears(ghg[regi, histYear, ], NULL)
       }
+
+
       # 3. Type CO2 or GHG /GDP: relative reduction of CO2 or GHG intensity
     } else if (allowedType[data[regi, year, "Type"]] %in% c("GHG/GDP", "CO2/GDP")) { # GHG/GDP or CO2/GDP
 

--- a/R/toolCalcGhgTarget.R
+++ b/R/toolCalcGhgTarget.R
@@ -238,12 +238,12 @@ toolCalcGhgTarget <- function(x, subtype, subset) {
   # disaggregate to EU countries by GDP
   # disaggregation irrelevant as long as only EU-level NDC target is used
   EUR_regionmapping_countries <- regionmapping %>%
-                                  filter(RegionCode =="EUR") %>%
-                                  pull(CountryCode)
+                                  filter(.data$RegionCode =="EUR") %>%
+                                  pull(.data$CountryCode)
 
   EU_LULUCF <- toolAggregate(EU_LULUCF_assumption,
                              rel = regionmapping %>%
-                               filter(RegionCode =="EUR"),
+                               filter(.data$RegionCode =="EUR"),
                              weight = gdp[EUR_regionmapping_countries,"y2020","SSP2"])
 
   EmiLULUCFTargetYear[EUR_regionmapping_countries,c("y2030","y2035"),] <- EU_LULUCF

--- a/R/toolCalcGhgTarget.R
+++ b/R/toolCalcGhgTarget.R
@@ -226,6 +226,28 @@ toolCalcGhgTarget <- function(x, subtype, subset) {
   # LULUCF assumptions for target years 2030 and 2035, for all other target years zero LULUCF contributions assumed
   EmiLULUCFTargetYear <- IIASA_LULUCF[intersect(getRegions(EmiLULUCFTargetYear), getRegions(IIASA_LULUCF)), , ]
 
+  # manually fix EU LULUCF data because of issues / missing data in IIASA source
+  EU_LULUCF_assumption <- new.magpie( cells_and_regions = "EUR",
+                                      years = c("y2030","y2035"))
+
+  # Assume 310 MtCO2/yr LULUCF sink in 2030, which is the official EU target.
+  # Assume that this sink is maintained in 2035.
+  # https://www.consilium.europa.eu/en/press/press-releases/2023/03/28/fit-for-55-package-council-adopts-regulations-on-effort-sharing-and-land-use-and-forestry-sector/
+  EU_LULUCF_assumption["EUR",c("y2030","y2035"),] <- -310
+
+  # disaggregate to EU countries by GDP
+  # disaggregation irrelevant as long as only EU-level NDC target is used
+  EUR_regionmapping_countries <- regionmapping %>%
+                                  filter(RegionCode =="EUR") %>%
+                                  pull(CountryCode)
+
+  EU_LULUCF <- toolAggregate(EU_LULUCF_assumption,
+                             rel = regionmapping %>%
+                               filter(RegionCode =="EUR"),
+                             weight = gdp[EUR_regionmapping_countries,"y2020","SSP2"])
+
+  EmiLULUCFTargetYear[EUR_regionmapping_countries,c("y2030","y2035"),] <- EU_LULUCF
+
 
   # 5. Calculate country-level absolute emissions targets ----
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.265.0**
+R package **mrremind**, version **0.265.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.0, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-03-30},
+  date = {2026-04-20},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.265.0},
+  note = {Version: 0.265.1},
 }
 ```

--- a/man/convertNewClimate.Rd
+++ b/man/convertNewClimate.Rd
@@ -19,8 +19,8 @@ Converts conditional and unconditional capacity and production targets into tota
 For countries and years without targets, 2020 values from IRENA and BP are used to fill the gaps.
 }
 \details{
-Emission targets are represented by a GHG factor, which is the quotient of total GHG
-emissions in the target year divided by the CEDS GHG emissions in 2005.
+Emissions targets on absolute level for total GHG emissions without bunkers and land-use change emissions are calculated
+from country-specific target formulation and land-use change emissions data
 }
 \seealso{
 \code{\link[=readIRENA]{readIRENA()}}

--- a/man/convertUNFCCC_NDC.Rd
+++ b/man/convertUNFCCC_NDC.Rd
@@ -19,8 +19,8 @@ Converts conditional and unconditional capacity and production targets into tota
 For countries and years without targets, 2015 values from IRENA and BP are used to fill the gaps.
 }
 \details{
-Emission targets are represented by a GHG factor, which is the quotient of total GHG
-emissions in the target year divided by the CEDS GHG emissions in 2005.
+NDC Emissions targets on absolute level for total GHG emissions without bunkers and land-use change emissions are calculated
+from country-specific target formulation and land-use change emissions data
 }
 \seealso{
 \code{\link[=readIRENA]{readIRENA()}}


### PR DESCRIPTION
This PR again fixes the NDC emissions target calculation:

* generally take reference emissions from input sheet of PBL major emitters if available
* take official reference year emissions (UNFCCC) for China, India, Japan 
  * Japan emissions now come from PBL input excel sheet (see first bullet)
  * China and India reference year (2005) emissions come from UNFCCC GHG profile; for India no 2005 value reported so 2000-2010 mean was used
* assume -310 MtCo2/yr LULUCF sink for EU in 2030 and 2035 which is official EU target

