### PR TITLE
Add regional fossil capacity / power generation variables from IEA WEO2025 to historical mif

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '54512513'
+ValidationKey: '54538380'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.265.1
-date-released: '2026-04-20'
+version: 0.265.2
+date-released: '2026-04-22'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.265.1
-Date: 2026-04-20
+Version: 0.265.2
+Date: 2026-04-22
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcIEA_WorldEnergyOutlook.R
+++ b/R/calcIEA_WorldEnergyOutlook.R
@@ -101,6 +101,16 @@ calcIEA_WorldEnergyOutlook <- function() { # nolint
   dataGlo[, , "Cap|Electricity|Coal (GW)"] <-
     dataGlo[, , "Cap|Electricity|Coal|w/o CC (GW)"] + dataGlo[, , "Cap|Electricity|Coal|w/ CC (GW)"]
 
+  # for regional data, only without CCS available, still map to total capacity as in the near-term there is no difference between these variables
+  dataReg <- add_columns(dataReg, "Cap|Electricity|Coal (GW)", dim = 3.2)
+  dataReg[, , "Cap|Electricity|Coal (GW)"][, , getNames(dataReg[, , "Cap|Electricity|Coal|w/o CC (GW)"], dim=1)] <-
+    dataReg[, , "Cap|Electricity|Coal|w/o CC (GW)"]
+
+  # for regional data, only without CCS available, still map to total capacity as in the near-term there is no difference between these variables
+  dataReg <- add_columns(dataReg, "Cap|Electricity|Gas (GW)", dim = 3.2)
+  dataReg[, , "Cap|Electricity|Gas (GW)"][, , getNames(dataReg[, , "Cap|Electricity|Gas|w/o CC (GW)"], dim=1)] <-
+    dataReg[, , "Cap|Electricity|Gas|w/o CC (GW)"]
+
   dataGlo <- add_columns(dataGlo, "Cap|Electricity|Solar (GW)", dim = 3.2)
   dataGlo[, , "Cap|Electricity|Solar (GW)"] <-
     dataGlo[, , "Cap|Electricity|Solar|CSP (GW)"] + dataGlo[, , "Cap|Electricity|Solar|PV (GW)"]
@@ -116,6 +126,16 @@ calcIEA_WorldEnergyOutlook <- function() { # nolint
   dataGlo <- add_columns(dataGlo, "SE|Electricity|Solar (EJ/yr)", dim = 3.2)
   dataGlo[, , "SE|Electricity|Solar (EJ/yr)"] <-
     dataGlo[, , "SE|Electricity|Solar|PV (EJ/yr)"] + dataGlo[, , "SE|Electricity|Solar|CSP (EJ/yr)"]
+
+  # for regional data, only without CCS available, still map to total capacity as in the near-term there is no difference between these variables
+  dataReg <- add_columns(dataReg, "SE|Electricity|Coal (EJ/yr)", dim = 3.2)
+  dataReg[, , "SE|Electricity|Coal (EJ/yr)"][, , getNames(dataReg[, , "SE|Electricity|Coal|w/o CC (EJ/yr)"], dim=1)] <-
+    dataReg[, , "SE|Electricity|Coal|w/o CC (EJ/yr)"]
+
+  # for regional data, only without CCS available, still map to total capacity as in the near-term there is no difference between these variables
+  dataReg <- add_columns(dataReg, "SE|Electricity|Gas (EJ/yr)", dim = 3.2)
+  dataReg[, , "SE|Electricity|Gas (EJ/yr)"][, , getNames(dataReg[, , "SE|Electricity|Gas|w/o CC (EJ/yr)"], dim=1)] <-
+    dataReg[, , "SE|Electricity|Gas|w/o CC (EJ/yr)"]
 
   # includes values from the original source for global region instead of calculating
   # it as the sum of all countries (as countries are incomplete)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.265.1**
+R package **mrremind**, version **0.265.2**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/mrremind)](https://cran.r-project.org/package=mrremind) [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
+   [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.2, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-04-20},
+  date = {2026-04-22},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.265.1},
+  note = {Version: 0.265.2},
 }
 ```


### PR DESCRIPTION
This is such that the IEA WEO2025 data shows up in the SE|Electricity|Coal/Gas and Cap|Electricity|Coal/Gas plots. 
