### PR TITLE
NDC target calculation fixes for China and India

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '54538380'
+ValidationKey: '54561598'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.265.2
-date-released: '2026-04-22'
+version: 0.265.3
+date-released: '2026-04-23'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.265.2
-Date: 2026-04-22
+Version: 0.265.3
+Date: 2026-04-23
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/readUNFCCC_NDC.R
+++ b/R/readUNFCCC_NDC.R
@@ -170,17 +170,20 @@ readUNFCCC_NDC <- function(subtype, subset) {
       ] <-
         list(0.944, "Excluding")
 
-      # China 2035 this target is including LULUCF emissions
-      # peak year =2025
-      # reference emissions in 2025:
-      # from REMIND_2026_01_22 NPi2025;Emi|GHG|w/o Bunkers|w/o Land-Use Change in  2025= 16079
-      # LULUCF in 2020= -1211.589 in 2030= -935 thus we assume -1000 in 2025
+      # Assume that China 2035 target is including LULUCF emissions
+      # Moreover, the target calculation requires some assumption about the peaking year emissions
+      # For this, check peaking year emissions in NPi2025 run from REMIND v3.6 master
+      # (/p/projects/remind/runs/REMIND_master_v3p6p0_2026_03_27/remind/output/SSP2-NPi2025_2026-03-27_18.02.18)
+      # Here, China emissions excl. LULUCF (Emi|GHG|w/o Bunkers|w/o Land-Use Change) peak in 2025 at 16439 MtCO2eq/yr.
+      # Furthermore, assume -1 GtCO2/yr LULUCF emissions in 2025
+      # (IIASA NDC scenario had -1.2 Gt in 2020, -935 in 2030)
+      # This gives about 15500 MtCo2eq/yr total GHG incl. LULUCF reference emissions for the China peaking year.
 
       majorE[
         majorE$ISO_Code == "CHN" & majorE$Target_Year == 2035,
-        c("Reference_Year", "BAU_or_Reference_emissions_in_MtCO2e")
+        c("Reference_Year", "BAU_or_Reference_emissions_in_MtCO2e","LULUCF")
       ] <-
-        list("BAU", 15500)
+        list("BAU", 15500,"Including")
 
       # Saudi Arabia still wrong it is 2019 instead of BAU
       majorE[

--- a/R/toolCalcGhgTarget.R
+++ b/R/toolCalcGhgTarget.R
@@ -222,6 +222,10 @@ toolCalcGhgTarget <- function(x, subtype, subset) {
   # get LULUCF conditional NDC scenario data from IISAA for 2035
   IIASA_LULUCF_2035 <- readSource("IIASALanduse", subtype = "forecast2035")
 
+  # as India 2035 target has been added manually but was not present in the PBL data that provides the LULUCF 2035 emissions values,
+  # assume 2030 LULUCF emissions also for 2035 (as done for other countries, too)
+  IIASA_LULUCF_2035["IND","y2035",] <- collapseNames(IIASA_LULUCF_2030["IND","y2030",])
+
   IIASA_LULUCF <- mbind(
     IIASA_LULUCF_2030,
     IIASA_LULUCF_2035

--- a/R/toolCalcGhgTarget.R
+++ b/R/toolCalcGhgTarget.R
@@ -141,12 +141,12 @@ toolCalcGhgTarget <- function(x, subtype, subset) {
 
 
     if ("LULUCF" %in% getNames(data) && data[regi, year, "LULUCF"] > 0 &&
-      # actually of target year
-      emiRef[regi, 2015, "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] > 0 &&
       # if ghgTarget could not be set due to an invalid target formulation in the source, skip this step
       year %in% c("y2030", "y2035")) {
-      # subtract LULUCF from target to consistently apply Emi|GHG|w/o Bunkers|w/o Land-Use Change
-      ghgTarget <- ghgTarget[regi, year, ] - EmiLULUCFTargetYear[regi, year, ]
+      # subtract LULUCF from target to consistently apply Emi|GHG|w/o Bunkers|w/o Land-Use Change if available
+      if (!is.na(EmiLULUCFTargetYear[regi, year, ])) {
+        ghgTarget <- ghgTarget[regi, year, ] - EmiLULUCFTargetYear[regi, year, ]
+      }
     }
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.265.2**
+R package **mrremind**, version **0.265.3**
 
    [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.2, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.3, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-04-22},
+  date = {2026-04-23},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.265.2},
+  note = {Version: 0.265.3},
 }
 ```


### PR DESCRIPTION
Another set of fixes on the target calculation:

* assume China 2035 target to apply to total GHG incl. LULUCF (as "economy-wide reduction of GHG emissions" suggests)
* assume that India keeps LULUCF emissions of 2030 in 2035 (similar to what has been assumed for other countries)
* substract LULUCF to get to total GHG excl. LULUCF for all countries where the LULUCF data is available 
(replace ``emiRef[regi, 2015, "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"]`` by  
``!is.na(EmiLULUCFTargetYear[regi, year, ])`` condition)