### PR TITLE
bugfix NDC targets: emissions data used for aggregation weights for India/China were accidentally set to 0

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '54561598'
+ValidationKey: '54619320'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.265.3
-date-released: '2026-04-23'
+version: 0.265.4
+date-released: '2026-05-07'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.265.3
-Date: 2026-04-23
+Version: 0.265.4
+Date: 2026-05-07
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcEmiTargetReference.R
+++ b/R/calcEmiTargetReference.R
@@ -86,11 +86,18 @@ calcEmiTargetReference <- function() {
     getItems(readSource("UNFCCC", convert = FALSE), dim = 1)
   )
 
-  # also take China and India from UNFCCC as data from GHG profile was manually entered above
-  unfcccReg <- c(unfcccReg,"CHN","IND")
 
   out <- ghgCEDS
   out[unfcccReg, , ] <- ghgUNFCCC[unfcccReg, , ]
+
+
+  # for India and China take 2005 emissions from UNFCCC
+  # to get correct reference emissions for their NDC emissions targets
+  # where 2005 is the reference year
+  out[c("CHN","IND"), "y2005", ] <- ghgUNFCCC[c("CHN","IND"), "y2005", ]
+
+
+
 
   # fill gaps for LULUCF national accounting with IIASA data ----
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.265.3**
+R package **mrremind**, version **0.265.4**
 
    [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.3, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.265.4, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-04-23},
+  date = {2026-05-07},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.265.3},
+  note = {Version: 0.265.4},
 }
 ```


### PR DESCRIPTION
Emissions data used for aggregation weights for India/China were accidentally set to 0 as we overwrote with UNFCCC data for all years. Use CEDS data for this again and only replace 2005 values by UNFCCC data as these are the India/China target reference years. 

The India/China targets are as now what I expected from back-of-the-envelope calculation:

```
HPC2024 - schreyer@login03:/p/tmp/schreyer/Modeling/remind/Dev1/output/SSP2-NDC_2026-05-04_15.39.36> dumpgdx fulldata.gdx p45_CO2eqwoLU_goal "(CHA|IND)"
2030  CHA  14386.8684505262
2030  IND  4526.6211
2035  CHA  15165.5419266043
2035  IND  5362.2137
```