### PR TITLE
update transport variables, include industry subsector totals

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '559252190'
+ValidationKey: '559272819'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.271.10
+version: 0.271.11
 date-released: '2026-06-25'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.271.10
+Version: 0.271.11
 Date: 2026-06-25
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/calcUNFCCC.R
+++ b/R/calcUNFCCC.R
@@ -239,6 +239,29 @@ calcUNFCCC <- function() {
     x[, , "Emi|CO2|Industrial Processes (Mt CO2/yr)"] +
     x[, , "Emi|CO2|Energy|Demand|Industry (Mt CO2/yr)"]
 
+  x <- add_columns(x, "Emi|CO2|Industry|Cement (Mt CO2/yr)", dim = 3.1)
+  x[, , "Emi|CO2|Industry|Cement (Mt CO2/yr)"] <-
+    x[, , "Emi|CO2|Industrial Processes|Cement (Mt CO2/yr)"] +
+    x[, , "Emi|CO2|Energy|Demand|Industry|Cement (Mt CO2/yr)"]
+
+  x <- add_columns(x, "Emi|CO2|Industry|Steel (Mt CO2/yr)", dim = 3.1)
+  x[, , "Emi|CO2|Industry|Steel (Mt CO2/yr)"] <-
+    x[, , "Emi|CO2|Industrial Processes|Steel (Mt CO2/yr)"] +
+    x[, , "Emi|CO2|Energy|Demand|Industry|Steel (Mt CO2/yr)"]
+
+  x <- add_columns(x, "Emi|CO2|Industry|Chemicals (Mt CO2/yr)", dim = 3.1)
+  x[, , "Emi|CO2|Industry|Chemicals (Mt CO2/yr)"] <-
+    x[, , "Emi|CO2|Industrial Processes|Chemicals (Mt CO2/yr)"] +
+    x[, , "Emi|CO2|Energy|Demand|Industry|Chemicals (Mt CO2/yr)"]
+
+  x <- add_columns(x, "Emi|CO2|Industry|Other Industry (Mt CO2/yr)", dim = 3.1)
+  x[, , "Emi|CO2|Industry|Other Industry (Mt CO2/yr)"] <-
+    x[, , "Emi|CO2|Industrial Processes (Mt CO2/yr)"] -
+    x[, , "Emi|CO2|Industrial Processes|Chemicals (Mt CO2/yr)"] -
+    x[, , "Emi|CO2|Industrial Processes|Steel (Mt CO2/yr)"] -
+    x[, , "Emi|CO2|Industrial Processes|Cement (Mt CO2/yr)"] +
+    x[, , "Emi|CO2|Energy|Demand|Industry|Other Industry (Mt CO2/yr)"]
+
   x <- add_columns(x, "Emi|GHG|Industry (Mt CO2eq/yr)", dim = 3.1)
   x[, , "Emi|GHG|Industry (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|Industrial Processes (Mt CO2eq/yr)"] +

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.271.10**
+R package **mrremind**, version **0.271.11**
 
    [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.271.10, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.271.11, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,6 +50,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-06-25},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.271.10},
+  note = {Version: 0.271.11},
 }
 ```

--- a/inst/extdata/reportingVariables/Mapping_UNFCCC.csv
+++ b/inst/extdata/reportingVariables/Mapping_UNFCCC.csv
@@ -105,28 +105,28 @@ UNFCCC;Factor;REMIND;Unit_REMIND
 1.A.3. Transport|SO2;;;
 1.A.3.a. Domestic aviation|CH4;;;
 1.A.3.a. Domestic aviation|CO;;;
-1.A.3.a. Domestic aviation|CO2;0.001;Emi|CO2|Transport|Pass|Aviation|Domestic|Demand;Mt CO2/yr
+1.A.3.a. Domestic aviation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Pass|Domestic Aviation;Mt CO2/yr
 1.A.3.a. Domestic aviation|N2O;;;
 1.A.3.a. Domestic aviation|NMVOC;;;
 1.A.3.a. Domestic aviation|NOX;;;
 1.A.3.a. Domestic aviation|SO2;;;
 1.A.3.b. Road transportation|CH4;;;
 1.A.3.b. Road transportation|CO;;;
-1.A.3.b. Road transportation|CO2;0.001;Emi|CO2|Transport|Pass|Road|Demand;Mt CO2/yr
+1.A.3.b. Road transportation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Road;Mt CO2/yr
 1.A.3.b. Road transportation|N2O;;;
 1.A.3.b. Road transportation|NMVOC;;;
 1.A.3.b. Road transportation|NOX;;;
 1.A.3.b. Road transportation|SO2;;;
 1.A.3.c. Railways|CH4;;;
 1.A.3.c. Railways|CO;;;
-1.A.3.c. Railways|CO2;0.001;Emi|CO2|Transport|Pass|Rail|Demand;Mt CO2/yr
+1.A.3.c. Railways|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Rail;Mt CO2/yr
 1.A.3.c. Railways|N2O;;;
 1.A.3.c. Railways|NMVOC;;;
 1.A.3.c. Railways|NOX;;;
 1.A.3.c. Railways|SO2;;;
 1.A.3.d. Domestic navigation|CH4;;;
 1.A.3.d. Domestic navigation|CO;;;
-1.A.3.d. Domestic navigation|CO2;0.001;Emi|CO2|Transport|Freight|Navigation|Demand;Mt CO2/yr
+1.A.3.d. Domestic navigation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Freight|Domestic Shipping;Mt CO2/yr
 1.A.3.d. Domestic navigation|N2O;;;
 1.A.3.d. Domestic navigation|NMVOC;;;
 1.A.3.d. Domestic navigation|NOX;;;
@@ -263,16 +263,16 @@ UNFCCC;Factor;REMIND;Unit_REMIND
 1.D.1. International bunkers|NMVOC;;;
 1.D.1. International bunkers|NOX;;;
 1.D.1. International bunkers|SO2;;;
-1.D.1.a. Aviation|CH4;0.001;Emi|CH4|Transport|Pass|Aviation|International|Demand;Mt CH4/yr
+1.D.1.a. Aviation|CH4;0.001;Emi|CH4|Energy|Demand|Transport|Bunkers|Pass|International Aviation;Mt CH4/yr
 1.D.1.a. Aviation|CO;;;
-1.D.1.a. Aviation|CO2;0.001;Emi|CO2|Transport|Pass|Aviation|International|Demand;Mt CO2/yr
-1.D.1.a. Aviation|N2O;1;Emi|N2O|Transport|Pass|Aviation|International|Demand;kt N2O/yr
+1.D.1.a. Aviation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Bunkers|Pass|International Aviation;Mt CO2/yr
+1.D.1.a. Aviation|N2O;1;Emi|N2O|Energy|Demand|Transport|Bunkers|Pass|International Aviation;kt N2O/yr
 1.D.1.a. Aviation|NMVOC;;;
 1.D.1.a. Aviation|NOX;;;
 1.D.1.a. Aviation|SO2;;;
-1.D.1.b. Navigation|CH4;0.001;Emi|CH4|Transport|Freight|International Shipping|Demand;Mt CH4/yr
-1.D.1.b. Navigation|CO2;0.001;Emi|CO2|Transport|Freight|International Shipping|Demand;Mt CO2/yr
-1.D.1.b. Navigation|N2O;1;Emi|N2O|Transport|Freight|International Shipping|Demand;kt N2O/yr
+1.D.1.b. Navigation|CH4;0.001;Emi|CH4|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;Mt CH4/yr
+1.D.1.b. Navigation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;Mt CO2/yr
+1.D.1.b. Navigation|N2O;1;Emi|N2O|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;kt N2O/yr
 1.D.2. Multilateral operations|CH4;;;
 1.D.2. Multilateral operations|CO;;;
 1.D.2. Multilateral operations|CO2;;;

--- a/inst/extdata/reportingVariables/Mapping_UNFCCC.csv
+++ b/inst/extdata/reportingVariables/Mapping_UNFCCC.csv
@@ -270,9 +270,9 @@ UNFCCC;Factor;REMIND;Unit_REMIND
 1.D.1.a. Aviation|NMVOC;;;
 1.D.1.a. Aviation|NOX;;;
 1.D.1.a. Aviation|SO2;;;
-1.D.1.b. Navigation|CH4;0.001;"Navigation|CH4;0.001;Emi|CH4|Transport|Freight|International Shipping|Demand";Mt CH4/yr
+1.D.1.b. Navigation|CH4;0.001;Emi|CH4|Transport|Freight|International Shipping|Demand;Mt CH4/yr
 1.D.1.b. Navigation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;Mt CO2/yr
-1.D.1.b. Navigation|N2O;1;"Navigation|N2O;1;Emi|N2O|Transport|Freight|International Shipping|Demand";kt N2O/yr
+1.D.1.b. Navigation|N2O;1;Emi|N2O|Transport|Freight|International Shipping|Demand;kt N2O/yr
 1.D.2. Multilateral operations|CH4;;;
 1.D.2. Multilateral operations|CO;;;
 1.D.2. Multilateral operations|CO2;;;

--- a/inst/extdata/reportingVariables/Mapping_UNFCCC.csv
+++ b/inst/extdata/reportingVariables/Mapping_UNFCCC.csv
@@ -263,16 +263,16 @@ UNFCCC;Factor;REMIND;Unit_REMIND
 1.D.1. International bunkers|NMVOC;;;
 1.D.1. International bunkers|NOX;;;
 1.D.1. International bunkers|SO2;;;
-1.D.1.a. Aviation|CH4;0.001;Emi|CH4|Energy|Demand|Transport|Bunkers|Pass|International Aviation;Mt CH4/yr
+1.D.1.a. Aviation|CH4;0.001;Emi|CH4|Transport|Pass|Aviation|International|Demand;Mt CH4/yr
 1.D.1.a. Aviation|CO;;;
 1.D.1.a. Aviation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Bunkers|Pass|International Aviation;Mt CO2/yr
-1.D.1.a. Aviation|N2O;1;Emi|N2O|Energy|Demand|Transport|Bunkers|Pass|International Aviation;kt N2O/yr
+1.D.1.a. Aviation|N2O;1;Emi|N2O|Transport|Pass|Aviation|International|Demand;kt N2O/yr
 1.D.1.a. Aviation|NMVOC;;;
 1.D.1.a. Aviation|NOX;;;
 1.D.1.a. Aviation|SO2;;;
-1.D.1.b. Navigation|CH4;0.001;Emi|CH4|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;Mt CH4/yr
+1.D.1.b. Navigation|CH4;0.001;"Navigation|CH4;0.001;Emi|CH4|Transport|Freight|International Shipping|Demand";Mt CH4/yr
 1.D.1.b. Navigation|CO2;0.001;Emi|CO2|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;Mt CO2/yr
-1.D.1.b. Navigation|N2O;1;Emi|N2O|Energy|Demand|Transport|Bunkers|Freight|International Shipping|Demand;kt N2O/yr
+1.D.1.b. Navigation|N2O;1;"Navigation|N2O;1;Emi|N2O|Transport|Freight|International Shipping|Demand";kt N2O/yr
 1.D.2. Multilateral operations|CH4;;;
 1.D.2. Multilateral operations|CO;;;
 1.D.2. Multilateral operations|CO2;;;
@@ -290,9 +290,10 @@ UNFCCC;Factor;REMIND;Unit_REMIND
 2. Total industrial processes|CO2;0.001;Emi|CO2|Industrial Processes;Mt CO2/yr
 2. Total industrial processes|N2O;1;Emi|N2O|Industrial Processes;kt N2O/yr
 2.A. Mineral industry|CO2;0.001;Emi|CO2|Industrial Processes|Minerals;Mt CO2/yr
-2.A.1. Cement production|CO2;;;
-2.A.2. Lime production|CO2;;;
-2.A.3. Glass production|CO2;;;
+2.A. Mineral industry|CO2;0.001;Emi|CO2|Industrial Processes|Cement;Mt CO2/yr
+2.A.1. Cement production|CO2;0.001;Emi|CO2|Industrial Processes|Cement_exactUNFCCC;Mt CO2/yr
+2.A.2. Lime production|CO2;0.001;Emi|CO2|Industrial Processes|Lime;Mt CO2/yr
+2.A.3. Glass production|CO2;0.001;Emi|CO2|Industrial Processes|Glass;Mt CO2/yr
 2.A.4. Other process uses of carbonates|CO2;;;
 2.B. Chemical industry|CH4;0.001;Emi|CH4|Industrial Processes|Chemicals;Mt CH4/yr
 2.B. Chemical industry|CO2;0.001;Emi|CO2|Industrial Processes|Chemicals;Mt CO2/yr
@@ -316,8 +317,11 @@ UNFCCC;Factor;REMIND;Unit_REMIND
 2.C. Metal industry|CH4;0.001;Emi|CH4|Industrial Processes|Metals;Mt CH4/yr
 2.C. Metal industry|CO2;0.001;Emi|CO2|Industrial Processes|Metals;Mt CO2/yr
 2.C. Metal industry|N2O;1;Emi|N2O|Industrial Processes|Metals;kt N2O/yr
-2.C.1. Iron and steel production|CH4;;;
-2.C.1. Iron and steel production|CO2;;;
+2.C. Metal industry|CH4;0.001;Emi|CH4|Industrial Processes|Steel;Mt CH4/yr
+2.C. Metal industry|CO2;0.001;Emi|CO2|Industrial Processes|Steel;Mt CO2/yr
+2.C. Metal industry|N2O;1;Emi|N2O|Industrial Processes|Steel;kt N2O/yr
+2.C.1. Iron and steel production|CH4;0.001;Emi|CH4|Industrial Processes|Iron and steel_exactUNFCCC;Mt CH4/yr
+2.C.1. Iron and steel production|CO2;0.001;Emi|CO2|Industrial Processes|Iron and steel_exactUNFCCC;Mt CO2/yr
 2.C.2. Ferroalloys production|CH4;;;
 2.C.2. Ferroalloys production|CO2;;;
 2.C.3. Aluminium production|CO2;;;


### PR DESCRIPTION
1. correct transport variable names so that they match current REMIND naming
2. add the subsector industry emissions sums of energy & industrial processes to facilitate comparison with REMIND