### PR TITLE
re-introduce non-specified buildings electricity demand

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56230375'
+ValidationKey: '56256462'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.272.5
-date-released: '2026-07-01'
+version: 0.272.6
+date-released: '2026-07-03'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.272.5
-Date: 2026-07-01
+Version: 0.272.6
+Date: 2026-07-03
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.272.5**
+R package **mrremind**, version **0.272.6**
 
    [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.272.5, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.272.6, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-07-01},
+  date = {2026-07-03},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.272.5},
+  note = {Version: 0.272.6},
 }
 ```

--- a/inst/extdata/sectoral/mappingEDGEBuildingsToREMIND.csv
+++ b/inst/extdata/sectoral/mappingEDGEBuildingsToREMIND.csv
@@ -9,6 +9,7 @@ cooking_elec_fe;feelrhcob
 cooking_natgas_fe;fegab
 cooking_petrol_fe;fehob
 ict_elec_fe;feelictb
+feothelec;feelalb
 feothgas;fegab
 feothheat;feheb
 feothliquid;fehob


### PR DESCRIPTION
In this PR I am fixing a bug introduced in PR #805 where I incorrectly removed the aggregation of non-specified / other electricity demand from the function `calcFeDemandONONSPEC` to non-heating buildings electricity demand (formerly `feelcb`). Given that the demand is not defined in its energy service, I decided to aggregate it to `feelalb` (fe electricity for appliances & lighting) since this is the most broad category we have. 

The bug was found when comparing input data from revisions 7.97 (before merge of PR #805) and 8.12 (most recent), when historical FE electricity demands for China deviated significantly. After the correction (8.12CHAelec), they now align nicely again. The deviation in future electricity projections comes from the introduction of exogenous ICT demand projections. 

<img width="1400" height="800" alt="CHA_elec" src="https://github.com/user-attachments/assets/94095f92-5158-4692-afc2-d4204eca1cb1" />

You can find the input data with revision `8.12CHAelec`.