### PR TITLE
Get PPP2MER conversion factors from GDPuc

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56333200'
+ValidationKey: '56356579'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.272.8
-date-released: '2026-07-16'
+version: 0.272.9
+date-released: '2026-07-17'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.272.8
-Date: 2026-07-16
+Version: 0.272.9
+Date: 2026-07-17
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcRatioPPP2MER.R
+++ b/R/calcRatioPPP2MER.R
@@ -6,6 +6,8 @@
 #'
 #' Missing conversion factors are set to 1 and regional aggregation is weighed by GDP from WDI-MI-James.
 #'
+#' This ratio is also reported as the Price Level Index (GDP) in the World Bank's WDI database, which is equal to our
+#' measure multiplied by 100.
 #'
 #' @param year An integer specifying the base year of conversion factor. Defaults to the base year of
 #' [mrdrivers::toolGetUnitDollar()], currently: `r mrdrivers::toolGetUnitDollar(returnOnlyBase = TRUE)`.
@@ -17,9 +19,12 @@
 #'
 calcRatioPPP2MER <- function(year = as.numeric(mrdrivers::toolGetUnitDollar(returnOnlyBase = TRUE))) {
 
-  data <- readSource("WDI", "PA.NUS.PPPC.RF")[, year, ]
-  # Replace 0s with 1s. This was done previously. Other solutions here should be taken into consideration.
-  data[data == 0] <- 1
+  # Converting 1s returns the conversion factors. Missing conversion factors are set to 1.
+  data <- GDPuc::toolConvertGDP(gdp = new.magpie(getISOlist(), fill = 1),
+                                unit_in = glue::glue("constant {year} Int$PPP"),
+                                unit_out = glue::glue("constant {year} US$MER"),
+                                replace_NAs = "no_conversion")
+
   # Set names and years to NULL, for GAMS interface to work.
   getNames(data) <- NULL
   getYears(data) <- NULL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.272.8**
+R package **mrremind**, version **0.272.9**
 
    [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.272.8, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.272.9, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-07-16},
+  date = {2026-07-17},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.272.8},
+  note = {Version: 0.272.9},
 }
 ```

--- a/man/calcRatioPPP2MER.Rd
+++ b/man/calcRatioPPP2MER.Rd
@@ -24,6 +24,9 @@ with base year equal to the \code{year} argument) from PPP to MER. So for exampl
 }
 \details{
 Missing conversion factors are set to 1 and regional aggregation is weighed by GDP from WDI-MI-James.
+
+This ratio is also reported as the Price Level Index (GDP) in the World Bank's WDI database, which is equal to our
+measure multiplied by 100.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
The price level ratio "PA.NUS.PPPC.RF" was discontinued by the World Bank: they now report a price level index (equal to the previous ratio scaled by 100). 

However, the conversion factors can be retrieved from GDPuc as well. The advantage of this is that all conversions within the input-data preparation pipeline now rely on GDPuc directly, guaranteeing a consistency, which previously was only given if the underlying source data of readWDI and the internal data of GDPuc were downloaded from the WDI on the same day.