### PR TITLE
Simplify calcUNFCCC (extract functions)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56436115'
+ValidationKey: '56430653'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '56430653'
+ValidationKey: '56622100'
 AcceptedWarnings:
 - Invalid URL: .*
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
-version: 0.273.1
-date-released: '2026-07-29'
+version: 0.274.0
+date-released: '2026-07-31'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'mrremind: MadRat REMIND Input Data Package'
 version: 0.273.1
-date-released: '2026-07-31'
+date-released: '2026-07-29'
 abstract: The mrremind packages contains data preprocessing for the REMIND model.
 authors:
 - family-names: Baumstark
@@ -67,6 +67,8 @@ authors:
   given-names: Gabriel
 - family-names: Dorndorf
   given-names: Tabea
+- family-names: Krogmann
+  given-names: Simon
 license: LGPL-3.0
 repository-code: https://github.com/pik-piam/mrremind
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
 Version: 0.273.1
-Date: 2026-07-31
+Date: 2026-07-29
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),
@@ -33,7 +33,8 @@ Authors@R: c(
     person("Rahel", "Mandaroux", role = "aut"),
     person("Johannes", "Koch", role = "aut"),
     person("Gabriel", "Abrahao", role = "aut"),
-    person("Tabea", "Dorndorf", role = "aut")
+    person("Tabea", "Dorndorf", role = "aut"),
+    person("Simon", "Krogmann", role = "aut")
   )
 Description: The mrremind packages contains data preprocessing for the
     REMIND model.
@@ -47,7 +48,7 @@ Depends:
     magclass (>= 6.16.1),
     mrcommons (>= 1.69.5), 
     mrenergy (>= 0.1.1),
-    mrcommonsenergy (>= 0.3.1),
+    mrcommonsenergy (>= 0.5.0),
     mrdrivers (>= 6.0.0),
     mrindustry (>= 0.18.5),
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrremind
 Title: MadRat REMIND Input Data Package
-Version: 0.273.1
-Date: 2026-07-29
+Version: 0.274.0
+Date: 2026-07-31
 Authors@R: c(
     person("Lavinia", "Baumstark", , "lavinia@pik-potsdam.de", role = c("aut", "cre")),
     person("Renato", "Rodrigues", role = "aut"),

--- a/R/calcUNFCCC.R
+++ b/R/calcUNFCCC.R
@@ -16,23 +16,24 @@ calcUNFCCC <- function(subtype = "all") {
 
   mapping <- toolGetMapping("Mapping_UNFCCC.csv", type = "reportingVariables", where = "mrremind") %>%
     select("variable" = "UNFCCC", "REMIND", "conversion" = "Factor", "Unit_REMIND") %>%
-    mutate("REMIND" = trimws(.data$REMIND),
-           "variable" = trimws(gsub("\\.", "_", .data$variable))) %>%
-    filter(!is.na(.data$REMIND), .data$REMIND != "")
+    mutate("REMIND" = trimws(.data[["REMIND"]]),
+           "variable" = trimws(gsub("\\.", "_", .data[["variable"]]))) %>%
+    filter(!is.na(.data[["REMIND"]]), .data[["REMIND"]] != "")
 
   df <- data %>%
-    mselect(variable = unique(mapping$variable)) %>%
-    quitte::as.quitte(na.rm = TRUE) %>%
-    filter(.data$period >= 1990)
+    mselect(variable = unique(mapping[["variable"]])) %>%
+    as.data.frame(rev = 3) %>%
+    filter(!is.na(.data[[".value"]])) %>%
+    filter(.data[["year"]] >= 1990)
 
   x <- left_join(df, mapping, by = "variable", relationship = "many-to-many") %>%
     mutate(
-      "value" = .data$value * .data$conversion,
-      "REMIND" = paste0(.data$REMIND, " (", .data$Unit_REMIND, ")")
+      "value" = .data[[".value"]] * .data[["conversion"]],
+      "REMIND" = paste0(.data[["REMIND"]], " (", .data[["Unit_REMIND"]], ")")
     ) %>%
-    select("variable" = "REMIND", "region", "period", "value")
+    select("variable" = "REMIND", "region", "year", "value")
 
-  x <- stats::aggregate(value ~ variable + region + period, x, sum) %>%
+  x <- stats::aggregate(value ~ variable + region + year, x, sum) %>%
     as.magpie()
 
   # fill missing values with 0, because there are assumed to be small
@@ -313,11 +314,11 @@ calcUNFCCC <- function(subtype = "all") {
   mapping <- toolGetMapping("regionmappingH12.csv",
                             type = "regional",
                             where = "mappingfolder") %>%
-    filter(.data$RegionCode %in% regions.fill)
+    filter(.data[["RegionCode"]] %in% regions.fill)
 
-  tmp <- result[unique(mapping$CountryCode), , ]
+  tmp <- result[unique(mapping[["CountryCode"]]), , ]
   tmp[is.na(tmp)] <- 0
-  result[unique(mapping$CountryCode), , ] <- tmp
+  result[unique(mapping[["CountryCode"]]), , ] <- tmp
 
   return(list(
     x = result, weight = NULL,

--- a/R/calcUNFCCC.R
+++ b/R/calcUNFCCC.R
@@ -38,82 +38,33 @@ calcUNFCCC <- function(subtype = "all") {
   # fill missing values with 0, because there are assumed to be small
   x[is.na(x)] <- 0
 
-  # aggregate pollutants ----
+  # aggregate by gas, structure:
+  # Emi|{gas}|w/o Bunkers|LULUCF national accounting ({unit} {gas}/yr) =
+  #    Emi|{gas}|Agriculture ({unit} {gas}/yr) +
+  #    Emi|{gas}|w/o Bunkers|Energy ({unit} {gas}/yr) +
+  #    Emi|{gas}|Industrial Processes ({unit} {gas}/yr) +
+  #    Emi|{gas}|Land-Use Change|LULUCF national accounting ({unit} {gas}/yr) +
+  #    Emi|{gas}|Waste ({unit} {gas}/yr)
+  .addAggregateByGasColumn <- function(x, gas, unit) {
+    newCol <- glue::glue("Emi|{gas}|w/o Bunkers|LULUCF national accounting ({unit} {gas}/yr)")
+    x <- add_columns(x, newCol, dim = 3.1)
 
-  x <- add_columns(x, "Emi|CH4|w/o Bunkers|LULUCF national accounting (Mt CH4/yr)", dim = 3)
-  x[, , "Emi|CH4|w/o Bunkers|LULUCF national accounting (Mt CH4/yr)"] <- dimSums(
-    x[, , c(
-      "Emi|CH4|Agriculture (Mt CH4/yr)",
-      "Emi|CH4|w/o Bunkers|Energy (Mt CH4/yr)",
-      "Emi|CH4|Industrial Processes (Mt CH4/yr)",
-      "Emi|CH4|Land-Use Change|LULUCF national accounting (Mt CH4/yr)",
-      "Emi|CH4|Waste (Mt CH4/yr)"
-    )],
-    dim = 3, na.rm = TRUE
-  )
+    x[, , newCol] <- dimSums(
+      x[, , c(
+        glue::glue("Emi|{gas}|Agriculture ({unit} {gas}/yr)"),
+        glue::glue("Emi|{gas}|w/o Bunkers|Energy ({unit} {gas}/yr)"),
+        glue::glue("Emi|{gas}|Industrial Processes ({unit} {gas}/yr)"),
+        glue::glue("Emi|{gas}|Land-Use Change|LULUCF national accounting ({unit} {gas}/yr)"),
+        glue::glue("Emi|{gas}|Waste ({unit} {gas}/yr)")
+      )],
+      dim = 3, na.rm = TRUE
+    )
+    return(x)
+  }
+  x <- .addAggregateByGasColumn(x, "CH4", "Mt") # Emi|CH4|w/o Bunkers|LULUCF national accounting (Mt CH4/yr)
+  x <- .addAggregateByGasColumn(x, "CO2", "Mt") # Emi|CO2|w/o Bunkers|LULUCF national accounting (Mt CO2/yr)
+  x <- .addAggregateByGasColumn(x, "N2O", "kt") # Emi|N2O|w/o Bunkers|LULUCF national accounting (kt N2O/yr)
 
-  x <- add_columns(x, "Emi|CO2|w/o Bunkers|LULUCF national accounting (Mt CO2/yr)", dim = 3)
-  x[, , "Emi|CO2|w/o Bunkers|LULUCF national accounting (Mt CO2/yr)"] <- dimSums(
-    x[, , c(
-      "Emi|CO2|Agriculture (Mt CO2/yr)",
-      "Emi|CO2|w/o Bunkers|Energy (Mt CO2/yr)",
-      "Emi|CO2|Industrial Processes (Mt CO2/yr)",
-      "Emi|CO2|Land-Use Change|LULUCF national accounting (Mt CO2/yr)",
-      "Emi|CO2|Waste (Mt CO2/yr)"
-    )],
-    dim = 3, na.rm = TRUE
-  )
-
-  x <- add_columns(x, "Emi|N2O|w/o Bunkers|LULUCF national accounting (kt N2O/yr)", dim = 3)
-  x[, , "Emi|N2O|w/o Bunkers|LULUCF national accounting (kt N2O/yr)"] <- dimSums(
-    x[, , c(
-      "Emi|N2O|Agriculture (kt N2O/yr)",
-      "Emi|N2O|w/o Bunkers|Energy (kt N2O/yr)",
-      "Emi|N2O|Industrial Processes (kt N2O/yr)",
-      "Emi|N2O|Land-Use Change|LULUCF national accounting (kt N2O/yr)",
-      "Emi|N2O|Waste (kt N2O/yr)"
-    )],
-    dim = 3, na.rm = TRUE
-  )
-
-  # add total GHG as CO2 equivalents for sectors ----
-
-  x <- add_columns(x, "Emi|GHG|w/o Bunkers|Energy (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|w/o Bunkers|Energy (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|w/o Bunkers|Energy (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|w/o Bunkers|Energy (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|w/o Bunkers|Energy (kt N2O/yr)"] / 1000 * 265
-
-  x <- add_columns(x, "Emi|GHG|Industrial Processes (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|Industrial Processes (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Industrial Processes (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Industrial Processes (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Industrial Processes (kt N2O/yr)"] / 1000 * 265
-
-  x <- add_columns(x, "Emi|GHG|Agriculture (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|Agriculture (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Agriculture (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Agriculture (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Agriculture (kt N2O/yr)"] / 1000 * 265
-
-  x <- add_columns(x, "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Land-Use Change|LULUCF national accounting (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Land-Use Change|LULUCF national accounting (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Land-Use Change|LULUCF national accounting (kt N2O/yr)"] / 1000 * 265
-
-  x <- add_columns(x, "Emi|GHG|Waste (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|Waste (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Waste (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Waste (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Waste (kt N2O/yr)"] / 1000 * 265
-
-  # GHG total
-  x <- add_columns(x, "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|w/o Bunkers|LULUCF national accounting (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|w/o Bunkers|LULUCF national accounting (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|w/o Bunkers|LULUCF national accounting (kt N2O/yr)"] / 1000 * 265
 
   # additional CO2 variables ----
 
@@ -127,14 +78,12 @@ calcUNFCCC <- function(subtype = "all") {
     x[, , "Emi|CO2|w/o Bunkers|Energy (Mt CO2/yr)"] +
     x[, , "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"]
 
-  x <- add_columns(x, "Emi|CO2|w/o Bunkers|Energy and Industrial Processes (Mt CO2/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|CO2|w/o Bunkers|Energy and Industrial Processes (Mt CO2/yr)", dim = 3)
   x[, , "Emi|CO2|w/o Bunkers|Energy and Industrial Processes (Mt CO2/yr)"] <-
     x[, , "Emi|CO2|w/o Bunkers|Energy (Mt CO2/yr)"] +
     x[, , "Emi|CO2|Industrial Processes (Mt CO2/yr)"]
 
-  x <- add_columns(x, "Emi|CO2|w/ Bunkers|Energy and Industrial Processes (Mt CO2/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|CO2|w/ Bunkers|Energy and Industrial Processes (Mt CO2/yr)", dim = 3)
   x[, , "Emi|CO2|w/ Bunkers|Energy and Industrial Processes (Mt CO2/yr)"] <-
     x[, , "Emi|CO2|w/o Bunkers|Energy and Industrial Processes (Mt CO2/yr)"] +
     x[, , "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"]
@@ -150,22 +99,44 @@ calcUNFCCC <- function(subtype = "all") {
     x[, , "Emi|CO2|w/o Bunkers|Energy|Demand (Mt CO2/yr)"] +
     x[, , "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"]
 
-  x <- add_columns(x, "Emi|CO2|w/ Bunkers|Energy|Demand|Transport (Mt CO2/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|CO2|w/ Bunkers|Energy|Demand|Transport (Mt CO2/yr)", dim = 3)
   x[, , "Emi|CO2|w/ Bunkers|Energy|Demand|Transport (Mt CO2/yr)"] <-
     x[, , "Emi|CO2|w/o Bunkers|Energy|Demand|Transport (Mt CO2/yr)"] +
     x[, , "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"]
 
+  # aggregate by sector (gases weighted by GWP), structure:
+  # Emi|GHG|{sector} (Mt CO2eq/yr) =
+  #    Emi|CO2|{sector} (Mt CO2/yr) +
+  #    Emi|CH4|{sector} (Mt CH4/yr) +
+  #    Emi|N2O|{sector} (kt N2O/yr)
+  .addAggregateBySectorColumn <- function(x, sector) {
+    new_col <- glue::glue("Emi|GHG|{sector} (Mt CO2eq/yr)")
+    x <- add_columns(x, new_col, dim = 3.1)
+    gwpCH4 <- 28
+    gwpN2O <- 265
+    x[, , new_col] <-
+      x[, , glue::glue("Emi|CO2|{sector} (Mt CO2/yr)")] +
+      x[, , glue::glue("Emi|CH4|{sector} (Mt CH4/yr)")] * gwpCH4 +
+      x[, , glue::glue("Emi|N2O|{sector} (kt N2O/yr)")] / 1000 * gwpN2O
+    return(x)
+  }
+
+  # Emi|GHG|w/o Bunkers|Energy (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "w/o Bunkers|Energy")
+  # Emi|GHG|Industrial Processes (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Industrial Processes")
+  # Emi|GHG|Agriculture (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Agriculture")
+  # Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Land-Use Change|LULUCF national accounting")
+  # Emi|GHG|Waste (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Waste")
+  # Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "w/o Bunkers|LULUCF national accounting")
+  # Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Energy|Demand|Transport|International Bunkers")
+
   # additional GHG variables ----
-
-  x <- add_columns(x, "Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Energy|Demand|Transport|International Bunkers (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Energy|Demand|Transport|International Bunkers (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Energy|Demand|Transport|International Bunkers (kt N2O/yr)"] / 1000 * 265
-
-
   x <- add_columns(x, "Emi|GHG|w/ Bunkers|LULUCF national accounting (Mt CO2eq/yr)", dim = 3)
   x[, , "Emi|GHG|w/ Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] +
@@ -177,53 +148,35 @@ calcUNFCCC <- function(subtype = "all") {
     x[, , "Emi|GHG|w/o Bunkers|Energy (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)"]
 
-  x <- add_columns(x, "Emi|GHG|w/o Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|GHG|w/o Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)", dim = 3)
   x[, , "Emi|GHG|w/o Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|w/o Bunkers|Energy (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|Industrial Processes (Mt CO2eq/yr)"]
 
-  x <- add_columns(x, "Emi|GHG|w/ Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|GHG|w/ Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)", dim = 3)
   x[, , "Emi|GHG|w/ Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|w/o Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)"]
 
-  x <- add_columns(x, "Emi|GHG|Energy|Demand|Industry (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|Energy|Demand|Industry (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Energy|Demand|Industry (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Energy|Demand|Industry (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Energy|Demand|Industry (kt N2O/yr)"] / 1000 * 265
+  # Emi|GHG|Energy|Demand|Industry (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Energy|Demand|Industry")
+  # Emi|GHG|w/o Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "w/o Bunkers|Energy|Demand|Transport")
+  # Emi|GHG|Energy|Demand|Buildings (Mt CO2eq/yr)
+  x <- .addAggregateBySectorColumn(x, "Energy|Demand|Buildings")
 
-
-  x <- add_columns(x, "Emi|GHG|w/o Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|w/o Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|w/o Bunkers|Energy|Demand|Transport (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|w/o Bunkers|Energy|Demand|Transport (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|w/o Bunkers|Energy|Demand|Transport (kt N2O/yr)"] / 1000 * 265
-
-  x <- add_columns(x, "Emi|GHG|Energy|Demand|Buildings (Mt CO2eq/yr)", dim = 3)
-  x[, , "Emi|GHG|Energy|Demand|Buildings (Mt CO2eq/yr)"] <-
-    x[, , "Emi|CO2|Energy|Demand|Buildings (Mt CO2/yr)"] +
-    x[, , "Emi|CH4|Energy|Demand|Buildings (Mt CH4/yr)"] * 28 +
-    x[, , "Emi|N2O|Energy|Demand|Buildings (kt N2O/yr)"] / 1000 * 265
-
-  x <- add_columns(x, "Emi|GHG|w/o Bunkers|Energy|Demand (Mt CO2eq/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|GHG|w/o Bunkers|Energy|Demand (Mt CO2eq/yr)", dim = 3)
   x[, , "Emi|GHG|w/o Bunkers|Energy|Demand (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|Energy|Demand|Industry (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|w/o Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|Energy|Demand|Buildings (Mt CO2eq/yr)"]
 
-  x <- add_columns(x, "Emi|GHG|w/ Bunkers|Energy|Demand (Mt CO2eq/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|GHG|w/ Bunkers|Energy|Demand (Mt CO2eq/yr)", dim = 3)
   x[, , "Emi|GHG|w/ Bunkers|Energy|Demand (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|w/o Bunkers|Energy|Demand (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)"]
 
-  x <- add_columns(x, "Emi|GHG|w/ Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)",
-                   dim = 3)
+  x <- add_columns(x, "Emi|GHG|w/ Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)", dim = 3)
   x[, , "Emi|GHG|w/ Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)"] <-
     x[, , "Emi|GHG|w/o Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)"] +
     x[, , "Emi|GHG|Energy|Demand|Transport|International Bunkers (Mt CO2eq/yr)"]
@@ -272,57 +225,37 @@ calcUNFCCC <- function(subtype = "all") {
     x[, , "Emi|GHG|w/o Bunkers|LULUCF national accounting (Mt CO2eq/yr)"] -
     x[, , "Emi|GHG|Land-Use Change|LULUCF national accounting (Mt CO2eq/yr)"]
 
+  .aliasColumn <- function(x, aliasName, existingColumn) {
+    stopifnot(existingColumn %in% getItems(x, dim = 3))
+    x <- add_columns(x, aliasName, dim = 3)
+    x[, , aliasName] <-
+      x[, , existingColumn]
+    return(x)
+  }
+
   # default variables equal to "w/ bunkers" variables
-  x <- add_columns(x, "Emi|CO2|LULUCF national accounting (Mt CO2/yr)",
-                   dim = 3)
-  x[, , "Emi|CO2|LULUCF national accounting (Mt CO2/yr)"] <-
-    x[, , "Emi|CO2|w/ Bunkers|LULUCF national accounting (Mt CO2/yr)"]
-
-  x <- add_columns(x, "Emi|CO2|Energy (Mt CO2/yr)",
-                   dim = 3)
-  x[, , "Emi|CO2|Energy (Mt CO2/yr)"] <-
-    x[, , "Emi|CO2|w/ Bunkers|Energy (Mt CO2/yr)"]
-
-  x <- add_columns(x, "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)",
-                   dim = 3)
-  x[, , "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)"] <-
-    x[, , "Emi|CO2|w/ Bunkers|Energy and Industrial Processes (Mt CO2/yr)"]
-
-  x <- add_columns(x, "Emi|CO2|Energy|Demand (Mt CO2/yr)",
-                   dim = 3)
-  x[, , "Emi|CO2|Energy|Demand (Mt CO2/yr)"] <-
-    x[, , "Emi|CO2|w/ Bunkers|Energy|Demand (Mt CO2/yr)"]
-
-  x <- add_columns(x, "Emi|CO2|Energy|Demand|Transport (Mt CO2/yr)",
-                   dim = 3)
-  x[, , "Emi|CO2|Energy|Demand|Transport (Mt CO2/yr)"] <-
-    x[, , "Emi|CO2|w/ Bunkers|Energy|Demand|Transport (Mt CO2/yr)"]
+  x <- .aliasColumn(x, "Emi|CO2|LULUCF national accounting (Mt CO2/yr)",
+                    "Emi|CO2|w/ Bunkers|LULUCF national accounting (Mt CO2/yr)")
+  x <- .aliasColumn(x, "Emi|CO2|Energy (Mt CO2/yr)",
+                    "Emi|CO2|w/ Bunkers|Energy (Mt CO2/yr)")
+  x <- .aliasColumn(x, "Emi|CO2|Energy and Industrial Processes (Mt CO2/yr)",
+                    "Emi|CO2|w/ Bunkers|Energy and Industrial Processes (Mt CO2/yr)")
+  x <- .aliasColumn(x, "Emi|CO2|Energy|Demand (Mt CO2/yr)",
+                    "Emi|CO2|w/ Bunkers|Energy|Demand (Mt CO2/yr)")
+  x <- .aliasColumn(x, "Emi|CO2|Energy|Demand|Transport (Mt CO2/yr)",
+                    "Emi|CO2|w/ Bunkers|Energy|Demand|Transport (Mt CO2/yr)")
 
 
-  x <- add_columns(x, "Emi|GHG|LULUCF national accounting (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|LULUCF national accounting (Mt CO2eq/yr)"] <-
-    x[, , "Emi|GHG|w/ Bunkers|LULUCF national accounting (Mt CO2eq/yr)"]
-
-  x <- add_columns(x, "Emi|GHG|Energy (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|Energy (Mt CO2eq/yr)"] <-
-    x[, , "Emi|GHG|w/ Bunkers|Energy (Mt CO2eq/yr)"]
-
-  x <- add_columns(x, "Emi|GHG|Energy and Industrial Processes (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|Energy and Industrial Processes (Mt CO2eq/yr)"] <-
-    x[, , "Emi|GHG|w/ Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)"]
-
-  x <- add_columns(x, "Emi|GHG|Energy|Demand (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|Energy|Demand (Mt CO2eq/yr)"] <-
-    x[, , "Emi|GHG|w/ Bunkers|Energy|Demand (Mt CO2eq/yr)"]
-
-  x <- add_columns(x, "Emi|GHG|Energy|Demand|Transport (Mt CO2eq/yr)",
-                   dim = 3)
-  x[, , "Emi|GHG|Energy|Demand|Transport (Mt CO2eq/yr)"] <-
-    x[, , "Emi|GHG|w/ Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)"]
+  x <- .aliasColumn(x, "Emi|GHG|LULUCF national accounting (Mt CO2eq/yr)",
+                    "Emi|GHG|w/ Bunkers|LULUCF national accounting (Mt CO2eq/yr)")
+  x <- .aliasColumn(x, "Emi|GHG|Energy (Mt CO2eq/yr)",
+                    "Emi|GHG|w/ Bunkers|Energy (Mt CO2eq/yr)")
+  x <- .aliasColumn(x, "Emi|GHG|Energy and Industrial Processes (Mt CO2eq/yr)",
+                    "Emi|GHG|w/ Bunkers|Energy and Industrial Processes (Mt CO2eq/yr)")
+  x <- .aliasColumn(x, "Emi|GHG|Energy|Demand (Mt CO2eq/yr)",
+                    "Emi|GHG|w/ Bunkers|Energy|Demand (Mt CO2eq/yr)")
+  x <- .aliasColumn(x, "Emi|GHG|Energy|Demand|Transport (Mt CO2eq/yr)",
+                    "Emi|GHG|w/ Bunkers|Energy|Demand|Transport (Mt CO2eq/yr)")
 
   # remove years before 1990 due to incomplete data
   x <- x[, seq(1986, 1989, 1), , invert = TRUE]

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.273.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T, Krogmann S (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.273.1, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
-  author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf},
-  date = {2026-07-31},
+  author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf and Simon Krogmann},
+  date = {2026-07-29},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
   note = {Version: 0.273.1},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat REMIND Input Data Package
 
-R package **mrremind**, version **0.273.1**
+R package **mrremind**, version **0.274.0**
 
    [![R build status](https://github.com/pik-piam/mrremind/workflows/check/badge.svg)](https://github.com/pik-piam/mrremind/actions) [![codecov](https://codecov.io/gh/pik-piam/mrremind/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrremind) [![r-universe](https://pik-piam.r-universe.dev/badges/mrremind)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Lavinia Baumstark <lavinia@pik-po
 
 To cite package **mrremind** in publications use:
 
-Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T, Krogmann S (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.273.1, <https://github.com/pik-piam/mrremind>.
+Baumstark L, Rodrigues R, Levesque A, Oeser J, Bertram C, Mouratiadou I, Malik A, Schreyer F, Soergel B, Rottoli M, Mishra A, Dirnaichner A, Pehl M, Giannousakis A, Klein D, Strefler J, Feldhaus L, Brecha R, Rauner S, Dietrich J, Bi S, Benke F, Weigmann P, Richters O, Hasse R, Fuchs S, Mandaroux R, Koch J, Abrahao G, Dorndorf T, Krogmann S (2026). "mrremind: MadRat REMIND Input Data Package." Version: 0.274.0, <https://github.com/pik-piam/mrremind>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,9 +47,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {mrremind: MadRat REMIND Input Data Package},
   author = {Lavinia Baumstark and Renato Rodrigues and Antoine Levesque and Julian Oeser and Christoph Bertram and Ioanna Mouratiadou and Aman Malik and Felix Schreyer and Bjoern Soergel and Marianna Rottoli and Abhijeet Mishra and Alois Dirnaichner and Michaja Pehl and Anastasis Giannousakis and David Klein and Jessica Strefler and Lukas Feldhaus and Regina Brecha and Sebastian Rauner and Jan Philipp Dietrich and Stephen Bi and Falk Benke and Pascal Weigmann and Oliver Richters and Robin Hasse and Sophie Fuchs and Rahel Mandaroux and Johannes Koch and Gabriel Abrahao and Tabea Dorndorf and Simon Krogmann},
-  date = {2026-07-29},
+  date = {2026-07-31},
   year = {2026},
   url = {https://github.com/pik-piam/mrremind},
-  note = {Version: 0.273.1},
+  note = {Version: 0.274.0},
 }
 ```

--- a/man/mrremind-package.Rd
+++ b/man/mrremind-package.Rd
@@ -50,6 +50,7 @@ Authors:
   \item Johannes Koch
   \item Gabriel Abrahao
   \item Tabea Dorndorf
+  \item Simon Krogmann
 }
 
 }


### PR DESCRIPTION
Extract functions from calcUNFCCC to avoid duplicate code. Specifically the duplicate aggregation by sector seemed very error-prone to me when editing magic numbers.